### PR TITLE
new struct tag format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Go-opt an opinionated command-line parser
+# goopt: an opinionated command-line parser
 
 [![GoDoc](https://godoc.org/github.com/napalu/go-opt?status.svg)](https://godoc.org/github.com/napalu/goopt)
 [![Go Report Card](https://goreportcard.com/badge/github.com/napalu/goopt)](https://goreportcard.com/report/github.com/napalu/goopt)
@@ -38,6 +38,11 @@ go get github.com/napalu/goopt
 
 ### Declarative Definition Using Struct Tags
 
+The following example creates two flags, `Verbose` and `Output`, and a command `create` with a subcommand `file`. The path `create file` is used to specify the name of the command for the `Output` flag. A path consist of the command name and any number of subcommands. Variables in the command path are evaluated in the command context they are defined in. A variable so defined can be shared with other commands and subcommands:
+`path:create file,create directory` would create two commands ('create file' and 'create directory') and the `Output` flag would be set to the value of the `Output` flag for both commands.
+
+The struct tag format shown below is the old format which is still supported but is deprecated. The reason for the deprecation, is that the new format allows the use of additional struct tags (such as json), as each struct tag is self-contained, consisting of a set of key:value pair containing the attribute name and the attribute value. The new format is shown in the next section. The basic difference is that the old format uses a tag per attribute which might collide with other struct tags whereas the new format uses a single tag to define all attributes.
+
 ```go
 package main
 
@@ -69,6 +74,88 @@ func main() {
     fmt.Println("Output:", opts.Output)
 }
 ```
+
+The tag format uses semicolon-separated key:value pairs:
+- `long`: Long name for the `flag` - defaults to the field name if not specified
+- `short`: Short (single-character) name of the `flag` when POSIX compatibility is enabled - otherwise can be a multi-character string used as a mnemonic for the `flag` name (default)
+- `desc`: Description of the `flag`
+- `type`: `Flag` type (single|standalone|chained) - defaults to single
+- `required`: Whether the `flag` is required (true|false) - defaults to true
+- `default`: Default value for the `flag`
+- `secure`: For `flag` containing password input (true|false) - defaults to false
+- `prompt`: Prompt text for secure input `flag`
+- `accepted`: `Flag` which matches on values using one or more patterns - a pattern can be a literal value or a regex pattern (e.g. `pattern:json|yaml,desc:Format type`)
+- `depends`: `Flag` dependencies - a dependency can be a flag or set of flags or a set of flags and values (e.g. `flag:output,values:[json,yaml]`)
+
+### New Struct Tag Format
+
+The new `goopt` tag format provides a more flexible way to define flags and commands. Commands can still be defined using the  `path:` attribute but flags can also be grouped by `command` structure. See the next example for details.
+
+```go
+package main
+
+import (
+   "os"
+   "fmt"
+   "github.com/napalu/goopt"
+)
+
+type Options struct {
+    // Basic flag (global)
+    Verbose bool `goopt:"name:verbose;short:v;desc:Enable verbose output"`
+    // Required flag with default value (global)
+    Output string `goopt:"name:output;desc:Output file;required:true;default:/tmp/out.txt"`
+    // Command with subcommands
+    Create struct { // Command
+        // Flag for 'create' command
+        Force bool `goopt:"name:force;desc:Force creation"`
+        User struct {       // Subcommand definition
+            // Flags for 'create user' command
+            Username string `goopt:"name:username;desc:Username to create;required:true"`
+            Password string `goopt:"name:password;desc:User password;secure:true;prompt:Password:"`
+        } `goopt:"kind:command;name:user;desc:Create user"`
+    }  `goopt:"kind:command;name:create;desc:Create resources"`
+    // Flag with accepted values and dependencies (global)
+    Format string `goopt:"name:format;desc:Output format;accepted:{pattern:json|yaml,desc:Format type};depends:{flag:output,values:[json,yaml]}"`
+    // Standalone flag (global)
+    DryRun bool `goopt:"name:dry-run;desc:Dry run mode;type:standalone"`
+    // List type with custom separator (global)
+    Tags []string `goopt:"name:tags;desc:List of tags;type:chained"`
+}
+
+
+func main() {
+    opts := &Options{}
+    parser, err := goopt.NewParserFromStruct(opts)
+    if err != nil {
+        fmt.Println("Error:", err)
+        return
+    }
+
+   if !parser.Parse(os.Args) {
+        parser.PrintUsageWithGroups(os.Stdout)
+        return
+    }
+
+    fmt.Println("Verbose:", opts.Verbose)
+    fmt.Println("Output:", opts.Output)
+}
+```
+
+The tag format uses semicolon-separated key:value pairs:
+- `goopt`: The tag name
+- `kind`: Specifies if it's a `flag` or `command` (default: flag)
+- `name`: Long name for the `flag`/`command` - defaults to the field name if not specified
+- `short`: Short (single-character) name of the `flag` when POSIX compatibility is enabled - otherwise can be a multi-character string used as a mnemonic for the flag name (default)
+- `desc`: Description of the `flag`/`command`
+- `type`: `Flag` type (single|standalone|chained) - defaults to single
+- `required`: Whether the `flag` is required (true|false) - defaults to true
+- `default`: Default value for the `flag`
+- `secure`: For `flag` containing password input (true|false) - defaults to false
+- `prompt`: Prompt text for secure input `flag`
+- `accepted`: `Flag` which matches on values using one or more patterns - a pattern can be a literal value or a regex pattern (e.g. `pattern:json|yaml,desc:Format type`)
+- `depends`: `Flag` dependencies - a dependency can be a flag or set of flags or a set of flags and values (e.g. `flag:output,values:[json,yaml]`)
+
 ### Programmatic Definition with Commands
 
 ```go

--- a/argument_config_funcs.go
+++ b/argument_config_funcs.go
@@ -1,5 +1,9 @@
 package goopt
 
+import (
+	"regexp"
+)
+
 // NewArg convenience initialization method to configure flags
 func NewArg(configs ...ConfigureArgumentFunc) *Argument {
 	argument := &Argument{}
@@ -167,15 +171,16 @@ func WithPostValidationFilter(filter FilterFunc) ConfigureArgumentFunc {
 // Each value can optionally have a description that will be shown in help text.
 func WithAcceptedValues(values []PatternValue) ConfigureArgumentFunc {
 	return func(argument *Argument, err *error) {
-		if argument.AcceptedValues == nil {
-			argument.AcceptedValues = make([]LiterateRegex, 0, len(values))
-		}
+		argument.AcceptedValues = values
 
 		for i := 0; i < len(values); i++ {
-			if e := argument.accept(values[i]); e != nil {
-				*err = *e
+			re, e := regexp.Compile(argument.AcceptedValues[i].Pattern)
+			if e != nil {
+				*err = e
 				return
 			}
+
+			argument.AcceptedValues[i].value = re
 		}
 	}
 }

--- a/parse/state.go
+++ b/parse/state.go
@@ -6,26 +6,30 @@ import (
 	"github.com/napalu/goopt/util"
 )
 
+// State represents the current state of the argument parser
 type State interface {
-	CurrentPos() int
-	SetPos(pos int)
-	SkipCurrent()
-	Args() []string
-	InsertArgsAt(pos int, newArgs ...string)
-	ReplaceArgs(newArgs ...string)
-	CurrentArg() string
-	Peek() string
-	Advance() bool // New method for advancing to the next argument
-	Len() int      // Gets the length of the argument list
+	CurrentPos() int                         // Get the current position
+	SetPos(pos int)                          // Set the current position
+	SkipCurrent()                            // Skip the current argument
+	Args() []string                          // Get the entire argument list
+	InsertArgsAt(pos int, newArgs ...string) // Insert new arguments at a specific position
+	ReplaceArgs(newArgs ...string)           // Replace the entire argument list
+	CurrentArg() string                      // Get the current argument
+	Peek() string                            // Peek at the next argument
+	Advance() bool                           // New method for advancing to the next argument
+	Len() int                                // Gets the length of the argument list
 }
 
-var InvalidPositionError = errors.New("invalid position")
+// ErrInvalidPosition is an error that occurs when an invalid position is accessed
+var ErrInvalidPosition = errors.New("invalid position")
 
+// DefaultState is the default implementation of the State interface
 type DefaultState struct {
 	pos  int
 	args []string
 }
 
+// NewState creates a new State instance with the given argument list
 func NewState(args []string) *DefaultState {
 	return &DefaultState{
 		pos:  -1,
@@ -33,34 +37,42 @@ func NewState(args []string) *DefaultState {
 	}
 }
 
+// CurrentPos returns the current position in the argument list
 func (s *DefaultState) CurrentPos() int {
 	return s.pos
 }
 
+// SetPos sets the current position in the argument list
 func (s *DefaultState) SetPos(pos int) {
 	s.pos = pos
 }
 
+// SkipCurrent advances the current position to the next argument
 func (s *DefaultState) SkipCurrent() {
 	s.pos++
 }
 
+// Args returns the entire argument list
 func (s *DefaultState) Args() []string {
 	return s.args
 }
 
+// CurrentArg returns the current argument
 func (s *DefaultState) CurrentArg() string {
 	return s.args[s.pos]
 }
 
+// InsertArgsAt inserts new arguments at a specific position
 func (s *DefaultState) InsertArgsAt(pos int, newArgs ...string) {
 	s.args = util.InsertSlice(s.args, pos, newArgs...)
 }
 
+// ReplaceArgs replaces the entire argument list with new arguments
 func (s *DefaultState) ReplaceArgs(newArgs ...string) {
 	s.args = newArgs
 }
 
+// Advance advances to the next argument, returning true if successful
 func (s *DefaultState) Advance() bool {
 	if s.pos+1 < len(s.args) {
 		s.pos++
@@ -69,6 +81,7 @@ func (s *DefaultState) Advance() bool {
 	return false
 }
 
+// Peek returns the next argument without advancing the current position
 func (s *DefaultState) Peek() string {
 	if s.pos+1 < len(s.args) {
 		return s.args[s.pos+1]
@@ -77,14 +90,16 @@ func (s *DefaultState) Peek() string {
 	return ""
 }
 
+// ArgAt returns the argument at a specific position
 func (s *DefaultState) ArgAt(pos int) (string, error) {
 	if pos < 0 || pos >= len(s.args) {
-		return "", InvalidPositionError
+		return "", ErrInvalidPosition
 	}
 
 	return s.args[pos], nil
 }
 
+// Len returns the length of the argument list
 func (s *DefaultState) Len() int {
 	return len(s.args)
 }

--- a/parse/tag.go
+++ b/parse/tag.go
@@ -1,0 +1,341 @@
+package parse
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// TagPatternValue represents a pattern and its description in tag format
+type TagPatternValue struct {
+	Pattern     string
+	Description string
+}
+
+// Dependencies maps flag names to their allowed values
+// empty slice means any value is acceptable
+type DependencyMap map[string][]string
+
+// Common error messages
+const (
+	errEmptyInput        = "empty %s"
+	errMalformedBraces   = "malformed braces in: %s"
+	errUnmatchedBrackets = "unmatched brackets in: %s"
+	errInvalidFormat     = "invalid format"
+	errEmptyKey          = "empty key in: %s"
+	errMissingValue      = "missing or empty %s in: %s"
+	errDuplicateFlag     = "duplicate flag: %s"
+	errEmptyValue        = "empty value in: %s"
+	errBothValues        = "cannot specify both 'value' and 'values' in: %s"
+)
+
+// PatternValue parses a pattern value in format {pattern:xyz,desc:abc}
+func PatternValue(input string) (*TagPatternValue, error) {
+	// Check for empty input
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil, fmt.Errorf(errEmptyInput, "pattern value")
+	}
+
+	// Check for proper braces
+	input = strings.Trim(input, "{}")
+	if strings.Count(input, "{") > 0 || strings.Count(input, "}") > 0 {
+		return nil, fmt.Errorf(errMalformedBraces, input)
+	}
+
+	parts := make(map[string]string)
+	for _, part := range strings.Split(input, ",") {
+		key, value, found := strings.Cut(part, ":")
+		if !found {
+			return nil, errors.New(errInvalidFormat)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			return nil, fmt.Errorf(errEmptyKey, input)
+		}
+		parts[key] = value
+	}
+
+	pattern, ok := parts["pattern"]
+	if !ok || pattern == "" {
+		return nil, fmt.Errorf(errMissingValue, "pattern", input)
+	}
+
+	desc, ok := parts["desc"]
+	if !ok || desc == "" {
+		return nil, fmt.Errorf(errMissingValue, "desc", input)
+	}
+
+	return &TagPatternValue{
+		Pattern:     pattern,
+		Description: desc,
+	}, nil
+}
+
+// PatternValues parses multiple pattern values
+func PatternValues(input string) ([]TagPatternValue, error) {
+	var result []TagPatternValue
+	entries := strings.Split(strings.Trim(input, "{}"), "},{")
+
+	for _, entry := range entries {
+		pv, err := PatternValue("{" + entry + "}")
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, *pv)
+	}
+
+	return result, nil
+}
+
+// Dependency parses a single dependency
+func Dependency(input string) (string, []string, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", nil, fmt.Errorf(errEmptyInput, "dependency")
+	}
+
+	// Validate braces
+	if !strings.HasPrefix(input, "{") || !strings.HasSuffix(input, "}") {
+		return "", nil, fmt.Errorf(errMalformedBraces, input)
+	}
+	input = strings.Trim(input, "{} \r\n")
+
+	// Parse key-value pairs while preserving brackets
+	parts := make(map[string]string)
+	var current strings.Builder
+	var bracketCount int
+
+	input = input + "," // Add trailing comma to simplify parsing
+	for i := 0; i < len(input); i++ {
+		ch := input[i]
+		switch ch {
+		case '[':
+			bracketCount++
+			current.WriteByte(ch)
+		case ']':
+			bracketCount--
+			if bracketCount < 0 {
+				return "", nil, fmt.Errorf(errUnmatchedBrackets, input)
+			}
+			current.WriteByte(ch)
+		case ',':
+			if bracketCount == 0 {
+				part := current.String()
+				key, value, found := strings.Cut(strings.TrimSpace(part), ":")
+				if !found {
+					if strings.Contains(part, "=") {
+						return "", nil, errors.New(errInvalidFormat)
+					}
+					return "", nil, fmt.Errorf(errMalformedBraces, input)
+				}
+				key = strings.TrimSpace(key)
+				value = strings.TrimSpace(value)
+				if key == "" {
+					return "", nil, fmt.Errorf(errEmptyKey, part)
+				}
+				parts[key] = value
+				current.Reset()
+				continue
+			}
+			current.WriteByte(ch)
+		default:
+			current.WriteByte(ch)
+		}
+	}
+
+	if bracketCount != 0 {
+		return "", nil, fmt.Errorf(errUnmatchedBrackets, input)
+	}
+
+	flag, ok := parts["flag"]
+	if !ok || flag == "" {
+		return "", nil, fmt.Errorf(errMissingValue, "flag", input)
+	}
+
+	// Handle values
+	if value, hasValue := parts["value"]; hasValue {
+		if _, hasValues := parts["values"]; hasValues {
+			return "", nil, fmt.Errorf(errBothValues, input)
+		}
+		if value == "" {
+			return "", nil, fmt.Errorf(errEmptyValue, input)
+		}
+		return flag, []string{value}, nil
+	}
+
+	if values, hasValues := parts["values"]; hasValues {
+		if len(values) > 1 && values[0] == '[' && values[len(values)-1] == ']' {
+			values = values[1 : len(values)-1]
+		}
+		if values == "" {
+			return flag, nil, nil
+		}
+
+		// Handle values with escaped characters
+		var valueList []string
+		var current strings.Builder
+		var escaped bool
+		var bracketCount int
+		var lastChar rune
+
+		values = values + "," // Add trailing comma to simplify parsing
+		for i := 0; i < len(values); i++ {
+			ch := values[i]
+			if escaped {
+				switch ch {
+				case '\\':
+					if lastChar == '\\' {
+						current.WriteByte('\\') // Double backslash becomes single
+					}
+				case ',':
+					current.WriteByte(',') // Escaped comma
+				case ' ':
+					current.WriteByte(' ') // Escaped space
+				default:
+					if lastChar == '\\' {
+						current.WriteByte('\\') // Preserve backslash in paths
+					}
+					current.WriteByte(ch)
+				}
+				escaped = false
+				continue
+			}
+
+			if ch == '\\' {
+				escaped = true
+				lastChar = '\\'
+				continue
+			}
+
+			if ch == '[' {
+				bracketCount++
+				current.WriteByte(ch)
+			} else if ch == ']' {
+				bracketCount--
+				current.WriteByte(ch)
+				// If we're back to bracket level 0 and next char is comma,
+				// this is a complete nested structure
+				if bracketCount == 0 && i+1 < len(values) && values[i+1] == ',' {
+					if v := strings.TrimSpace(current.String()); v != "" {
+						// For double-bracketed items, remove one level
+						if strings.HasPrefix(v, "[[") && strings.HasSuffix(v, "]]") {
+							v = v[1 : len(v)-1]
+						}
+						valueList = append(valueList, v)
+					}
+					current.Reset()
+					i++ // Skip the comma
+					continue
+				}
+			} else if ch == ',' && !escaped && bracketCount == 0 {
+				if v := strings.TrimSpace(current.String()); v != "" {
+					valueList = append(valueList, v)
+				}
+				current.Reset()
+				continue
+			} else {
+				current.WriteByte(ch)
+			}
+
+			lastChar = rune(ch)
+		}
+
+		// Don't forget the last value
+		if v := strings.TrimSpace(current.String()); v != "" {
+			// For double-bracketed items, remove one level
+			if strings.HasPrefix(v, "[[") && strings.HasSuffix(v, "]]") {
+				v = v[1 : len(v)-1]
+			}
+			valueList = append(valueList, v)
+		}
+
+		return flag, valueList, nil
+	}
+
+	return flag, nil, nil
+}
+
+// Dependencies parses multiple dependencies
+func Dependencies(input string) (DependencyMap, error) {
+	result := make(DependencyMap)
+
+	// Handle empty input
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil, fmt.Errorf(errEmptyInput, "dependency")
+	}
+
+	// Initial brace validation
+	if !strings.HasPrefix(strings.TrimSpace(input), "{") || !strings.HasSuffix(strings.TrimSpace(input), "}") {
+		return nil, fmt.Errorf(errMalformedBraces, input)
+	}
+
+	// Split dependencies while preserving brackets
+	var (
+		entries                  []string
+		current                  strings.Builder
+		bracketCount, braceCount int
+	)
+
+	for i := 0; i < len(input); i++ {
+		ch := input[i]
+		switch ch {
+		case '[':
+			bracketCount++
+			current.WriteByte(ch)
+		case ']':
+			bracketCount--
+			if bracketCount < 0 {
+				return nil, fmt.Errorf(errUnmatchedBrackets, input)
+			}
+			current.WriteByte(ch)
+		case '{':
+			braceCount++
+			current.WriteByte(ch)
+		case '}':
+			braceCount--
+			if braceCount < 0 {
+				return nil, fmt.Errorf(errMalformedBraces, input)
+			}
+			current.WriteByte(ch)
+		case ',':
+			if bracketCount == 0 && braceCount == 0 && i > 0 && input[i-1] == '}' && i+1 < len(input) && input[i+1] == '{' {
+				entries = append(entries, current.String())
+				current.Reset()
+				continue
+			}
+			current.WriteByte(ch)
+		default:
+			current.WriteByte(ch)
+		}
+	}
+
+	if bracketCount != 0 {
+		return nil, fmt.Errorf(errUnmatchedBrackets, input)
+	}
+	if braceCount != 0 {
+		return nil, fmt.Errorf(errMalformedBraces, input)
+	}
+
+	if current.Len() > 0 {
+		entries = append(entries, current.String())
+	}
+
+	// Check for duplicate flags
+	seenFlags := make(map[string]bool)
+	for _, entry := range entries {
+		flag, values, err := Dependency(entry)
+		if err != nil {
+			return nil, err
+		}
+		if seenFlags[flag] {
+			return nil, fmt.Errorf(errDuplicateFlag, flag)
+		}
+		seenFlags[flag] = true
+		result[flag] = values
+	}
+
+	return result, nil
+}

--- a/parse/tag_test.go
+++ b/parse/tag_test.go
@@ -1,0 +1,275 @@
+package parse
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParsePatternValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []TagPatternValue
+		wantErr bool
+	}{
+		{
+			name:  "single pattern",
+			input: "{pattern:json,desc:JSON format}",
+			want: []TagPatternValue{{
+				Pattern:     "json",
+				Description: "JSON format",
+			}},
+		},
+		{
+			name:  "multiple patterns",
+			input: "{pattern:json,desc:JSON format},{pattern:yaml,desc:YAML format}",
+			want: []TagPatternValue{
+				{Pattern: "json", Description: "JSON format"},
+				{Pattern: "yaml", Description: "YAML format"},
+			},
+		},
+		{
+			name:    "invalid format",
+			input:   "{pattern:json}",
+			wantErr: true,
+		},
+		{
+			name:    "missing pattern",
+			input:   "{desc:JSON format}",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := PatternValues(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParsePatternValues() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParsePatternValues() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseDependencies(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		want      DependencyMap
+		wantErr   bool
+		errString string
+	}{
+		// Single dependency cases
+		{
+			name:  "simple flag",
+			input: "{flag:input}",
+			want:  DependencyMap{"input": nil},
+		},
+		{
+			name:  "flag with value",
+			input: "{flag:type,value:json}",
+			want:  DependencyMap{"type": []string{"json"}},
+		},
+		{
+			name:  "flag with multiple values",
+			input: "{flag:env,values:[prod,stage]}",
+			want:  DependencyMap{"env": []string{"prod", "stage"}},
+		},
+		{
+			name:  "empty values list",
+			input: "{flag:env,values:[]}",
+			want:  DependencyMap{"env": nil},
+		},
+		{
+			name:  "values with whitespace",
+			input: "{flag:env,values:[ prod , stage ]}",
+			want:  DependencyMap{"env": []string{"prod", "stage"}},
+		},
+		// Multiple dependencies
+		{
+			name:  "multiple dependencies",
+			input: "{flag:format,value:json},{flag:compress,value:true}",
+			want: DependencyMap{
+				"format":   []string{"json"},
+				"compress": []string{"true"},
+			},
+		},
+		// Error cases
+		{
+			name:      "empty input",
+			input:     "",
+			wantErr:   true,
+			errString: "empty dependency",
+		},
+		{
+			name:      "malformed braces",
+			input:     "flag:input}",
+			wantErr:   true,
+			errString: "malformed braces",
+		},
+		{
+			name:      "missing flag",
+			input:     "{value:json}",
+			wantErr:   true,
+			errString: "missing or empty flag",
+		},
+		{
+			name:      "both value and values",
+			input:     "{flag:env,value:prod,values:[stage]}",
+			wantErr:   true,
+			errString: "cannot specify both",
+		},
+		{
+			name:      "empty value",
+			input:     "{flag:type,value:}",
+			wantErr:   true,
+			errString: "empty value",
+		},
+		{
+			name:      "invalid format",
+			input:     "{flag=input}",
+			wantErr:   true,
+			errString: "invalid format",
+		},
+		// Edge cases for brackets and values
+		{
+			name:  "nested brackets",
+			input: "{flag:env,values:[[prod\\,stage],[dev\\,test]]}",
+			want:  DependencyMap{"env": []string{"[prod,stage]", "[dev,test]"}},
+		},
+		{
+			name:  "simple list",
+			input: "{flag:env,values:[prod,stage]}",
+			want:  DependencyMap{"env": []string{"prod", "stage"}},
+		},
+		{
+			name:  "values with special chars",
+			input: "{flag:path,values:[/usr/bin,C:\\Program Files]}",
+			want:  DependencyMap{"path": []string{"/usr/bin", "C:\\Program Files"}},
+		},
+		{
+			name:  "multiple dependencies with complex values",
+			input: "{flag:env,values:[prod,stage]},{flag:path,value:/usr/bin},{flag:opts,values:[key=val,x=y]}",
+			want: DependencyMap{
+				"env":  []string{"prod", "stage"},
+				"path": []string{"/usr/bin"},
+				"opts": []string{"key=val", "x=y"},
+			},
+		},
+		// Edge cases for whitespace
+		{
+			name:  "excessive whitespace",
+			input: "  {  flag  :  env  ,  values  : [  prod  ,  stage  ]  }  ",
+			want:  DependencyMap{"env": []string{"prod", "stage"}},
+		},
+		{
+			name:  "newlines in input",
+			input: "{\nflag:env,\nvalues:[\nprod,\nstage\n]\n}",
+			want:  DependencyMap{"env": []string{"prod", "stage"}},
+		},
+		// Error cases
+		{
+			name:      "unmatched brackets in values",
+			input:     "{flag:env,values:[prod,stage}",
+			wantErr:   true,
+			errString: "unmatched brackets",
+		},
+		{
+			name:      "nested unmatched brackets",
+			input:     "{flag:env,values:[[prod,stage]}",
+			wantErr:   true,
+			errString: "unmatched brackets",
+		},
+		{
+			name:      "duplicate flags",
+			input:     "{flag:env,value:prod},{flag:env,value:stage}",
+			wantErr:   true,
+			errString: "duplicate flag",
+		},
+		{
+			name:  "empty parts between commas",
+			input: "{flag:env,values:[,prod,,stage,]}",
+			want:  DependencyMap{"env": []string{"prod", "stage"}},
+		},
+		{
+			name:  "escaped characters",
+			input: `{flag:path,value:C:\path\with\backslashes}`,
+			want:  DependencyMap{"path": []string{`C:\path\with\backslashes`}},
+		},
+		{
+			name:  "values with escaped commas",
+			input: `{flag:env,values:[prod\,stage,dev\,test]}`,
+			want:  DependencyMap{"env": []string{"prod,stage", "dev,test"}},
+		},
+		{
+			name:  "mixed normal and escaped commas",
+			input: `{flag:env,values:[prod\,stage,dev,test\,local]}`,
+			want:  DependencyMap{"env": []string{"prod,stage", "dev", "test,local"}},
+		},
+		{
+			name:  "escaped backslash and comma",
+			input: `{flag:path,values:[C:\\path\\with\\commas\,in\,it]}`,
+			want:  DependencyMap{"path": []string{`C:\path\with\commas,in,it`}},
+		},
+		// Bracket handling cases
+		{
+			name:  "nested brackets with multiple levels",
+			input: "{flag:env,values:[[prod\\,stage],[dev\\,test],[[qa\\,1,qa\\,2]]]}",
+			want:  DependencyMap{"env": []string{"[prod,stage]", "[dev,test]", "[qa,1,qa,2]"}},
+		},
+		{
+			name:  "brackets in middle of value",
+			input: "{flag:env,values:[pre[test]post,dev]}",
+			want:  DependencyMap{"env": []string{"pre[test]post", "dev"}},
+		},
+		{
+			name:  "empty brackets",
+			input: "{flag:env,values:[[]]}",
+			want:  DependencyMap{"env": []string{"[]"}},
+		},
+		{
+			name:  "multiple escaped characters",
+			input: "{flag:path,values:[C:\\\\Program\\ Files\\\\[x86],/usr/local/[bin]]}",
+			want:  DependencyMap{"path": []string{`C:\Program Files\[x86]`, `/usr/local/[bin]`}},
+		},
+		{
+			name:      "unbalanced nested brackets",
+			input:     "{flag:env,values:[[test]}",
+			wantErr:   true,
+			errString: "unmatched brackets",
+		},
+		{
+			name:      "missing outer brackets",
+			input:     "{flag:env,values:a,b,c}",
+			wantErr:   true,
+			errString: "malformed braces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Dependencies(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Dependencies() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errString) {
+					t.Errorf("Dependencies() error = %v, want error containing %v", err, tt.errString)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Dependencies() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Dependencies() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/parser_config_funcs.go
+++ b/parser_config_funcs.go
@@ -58,14 +58,6 @@ func WithFlag(flag string, argument *Argument) ConfigureCmdLineFunc {
 	}
 }
 
-// WithEnvFilter accepts a func(flag string) string callback - if a non-empty string is returned
-// and a matching environment variable is found it will be prepended  to command args
-func WithEnvFilter(filter EnvFunc) ConfigureCmdLineFunc {
-	return func(cmdLine *Parser, err *error) {
-		cmdLine.envFilter = filter
-	}
-}
-
 // WithBindFlag is a wrapper to BindFlag which is used to bind a pointer to a variable with a flag.
 // If `bindVar` is not a pointer, an error is returned
 // The following variable types are supported:
@@ -129,5 +121,26 @@ func WithArgumentPrefixes(prefixes []rune) ConfigureCmdLineFunc {
 func WithPosix(usePosix bool) ConfigureCmdLineFunc {
 	return func(cmdLine *Parser, err *error) {
 		cmdLine.SetPosix(usePosix)
+	}
+}
+
+// WithCommandNameConverter allows setting a custom name converter for command names
+func WithCommandNameConverter(converter NameConversionFunc) ConfigureCmdLineFunc {
+	return func(cmdLine *Parser, err *error) {
+		cmdLine.SetCommandNameConverter(converter)
+	}
+}
+
+// WithFlagNameConverter allows setting a custom name converter for flag names
+func WithFlagNameConverter(converter NameConversionFunc) ConfigureCmdLineFunc {
+	return func(cmdLine *Parser, err *error) {
+		cmdLine.SetFlagNameConverter(converter)
+	}
+}
+
+// WithEnvNameConverter allows setting a custom name converter for environment variable names
+func WithEnvNameConverter(converter NameConversionFunc) ConfigureCmdLineFunc {
+	return func(cmdLine *Parser, err *error) {
+		cmdLine.SetEnvNameConverter(converter)
 	}
 }

--- a/types/orderedmap/ordered_map.go
+++ b/types/orderedmap/ordered_map.go
@@ -31,36 +31,6 @@ type keyValue[K comparable, V any] struct {
 	value V
 }
 
-func newIterator[K comparable, V any](o *OrderedMap[K, V], forward bool) *Iterator[K, V] {
-	iter := &Iterator[K, V]{
-		forward: forward,
-	}
-
-	if o == nil {
-		return nil
-	}
-
-	if o.keys.Len() == 0 {
-		return nil
-	}
-
-	if forward {
-		iter.ll = o.keys.Front()
-	} else {
-		iter.ll = o.keys.Back()
-	}
-
-	if iter.ll == nil {
-		return nil
-	}
-
-	keyVal := iter.ll.Value.(keyValue[K, V])
-	iter.Key = &keyVal.key
-	iter.Value = keyVal.value
-
-	return iter
-}
-
 // Next gets the next keyValue or nil when no more values can be iterated on
 func (n *Iterator[K, V]) Next() *Iterator[K, V] {
 	if n.ll == nil {
@@ -187,4 +157,34 @@ func (o *OrderedMap[K, V]) Front() *Iterator[K, V] {
 // Back returns an Iterator pointing to the newest (inserted-last) keyValue
 func (o *OrderedMap[K, V]) Back() *Iterator[K, V] {
 	return newIterator[K, V](o, false)
+}
+
+func newIterator[K comparable, V any](o *OrderedMap[K, V], forward bool) *Iterator[K, V] {
+	iter := &Iterator[K, V]{
+		forward: forward,
+	}
+
+	if o == nil {
+		return nil
+	}
+
+	if o.keys.Len() == 0 {
+		return nil
+	}
+
+	if forward {
+		iter.ll = o.keys.Front()
+	} else {
+		iter.ll = o.keys.Back()
+	}
+
+	if iter.ll == nil {
+		return nil
+	}
+
+	keyVal := iter.ll.Value.(keyValue[K, V])
+	iter.Key = &keyVal.key
+	iter.Value = keyVal.value
+
+	return iter
 }

--- a/util/terminal_test.go
+++ b/util/terminal_test.go
@@ -8,9 +8,9 @@ import (
 
 // MockTerminal for testing
 type MockTerminal struct {
-	Password         []byte
-	IsTerminalResult bool
-	Err              error
+	Password    []byte
+	IsATerminal bool
+	Err         error
 }
 
 func (m *MockTerminal) ReadPassword(fd int) ([]byte, error) {
@@ -18,7 +18,7 @@ func (m *MockTerminal) ReadPassword(fd int) ([]byte, error) {
 }
 
 func (m *MockTerminal) IsTerminal(fd int) bool {
-	return m.IsTerminalResult
+	return m.IsATerminal
 }
 
 func TestGetSecureString(t *testing.T) {
@@ -61,9 +61,9 @@ func TestGetSecureString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			mock := &MockTerminal{
-				Password:         tt.mockPassword,
-				IsTerminalResult: tt.isTerminal,
-				Err:              tt.mockErr,
+				Password:    tt.mockPassword,
+				IsATerminal: tt.isTerminal,
+				Err:         tt.mockErr,
 			}
 
 			got, err := GetSecureString(tt.prompt, &buf, mock)


### PR DESCRIPTION
support for custom terminals
support for declaration of command structs and grouped flags 'accepted' (pattern matching) and 'depends' (flag dependencies) tags more examples / explanations in the readme
additional tests for new functionality
*breaking* SetEnvFilter has been replaced by EnvNameConverter for consistency with the other converters