### PR TITLE
breaking: refactor(positional): simplify positional arguments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,17 @@ jobs:
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a
         with:
           go-version: ${{ matrix.go-version }}
+      - name: Debug File Content
+        run: |
+          echo "=== Checking parse/tag_test.go ==="
+          cat parse/tag_test.go
+          echo "=== Line 497 context ==="
+          sed -n '492,502p' parse/tag_test.go
+          echo "=== Git Status ==="
+          git status
+          echo "=== Git Branch Info ==="
+          git branch -v
+        shell: bash
       - name: Clean Go Caches
         run: |
           go clean -cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,16 @@ jobs:
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a
         with:
           go-version: ${{ matrix.go-version }}
+      - name: Clean Go Caches
+        run: |
+          go clean -cache
+          go clean -testcache
+          go clean -modcache
+          rm -rf pkg/
+        shell: bash
       - name: Run Test
         run: |
+          go mod tidy
           go test ./...
   update-badge:
     needs: test  # This ensures all tests pass first

--- a/argument.go
+++ b/argument.go
@@ -1,0 +1,135 @@
+package goopt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/napalu/goopt/types"
+)
+
+// Argument defines a command-line Flag
+type Argument struct {
+	Description    string
+	TypeOf         types.OptionType
+	Required       bool
+	RequiredIf     RequiredIfFunc
+	PreFilter      FilterFunc
+	PostFilter     FilterFunc
+	AcceptedValues []types.PatternValue
+	DependsOn      []string // Deprecated: use DependencyMap instead - will be removed in v2.0.0
+	OfValue        []string // Deprecated: use DependencyMap instead - will be removed in v2.0.0
+	DependencyMap  map[string][]string
+	Secure         types.Secure
+	Short          string
+	DefaultValue   string
+	Capacity       int // For slices, the capacity of the slice, ignored for other types
+	Position       *int
+}
+
+// NewArgument convenience initialization method to describe Flags. Alternatively, Use NewArg to
+// configure Argument using option functions.
+func NewArgument(shortFlag string, description string, typeOf types.OptionType, required bool, secure types.Secure, defaultValue string) *Argument {
+	return &Argument{
+		Description:  description,
+		TypeOf:       typeOf,
+		Required:     required,
+		DependsOn:    []string{},
+		OfValue:      []string{},
+		Secure:       secure,
+		Short:        shortFlag,
+		DefaultValue: defaultValue,
+	}
+}
+
+// NewArg convenience initialization method to configure flags
+func NewArg(configs ...ConfigureArgumentFunc) *Argument {
+	argument := &Argument{}
+	for _, config := range configs {
+		config(argument, nil)
+	}
+
+	return argument
+}
+
+// Set configures the Argument instance with the provided ConfigureArgumentFunc(s),
+// and returns an error if a configuration results in an error.
+//
+// Usage example:
+//
+//	arg := &Argument{}
+//	err := arg.Set(
+//	    WithDescription("example argument"),
+//	    WithType(Standalone),
+//	    SetRequired(true),
+//	)
+//	if err != nil {
+//	    // handle error
+//	}
+func (a *Argument) Set(configs ...ConfigureArgumentFunc) error {
+	a.ensureInit()
+	var err error
+	for _, config := range configs {
+		config(a, &err)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// String returns a string representation of the Argument instance
+func (a *Argument) String() string {
+	return strings.TrimLeft(fmt.Sprintf("%s %s %s", a.short(), a.description(), a.required()), " ")
+}
+
+func (a *Argument) ensureInit() {
+	if a.DependsOn == nil {
+		a.DependsOn = []string{}
+	}
+	if a.OfValue == nil {
+		a.OfValue = []string{}
+	}
+	if a.AcceptedValues == nil {
+		a.AcceptedValues = []types.PatternValue{}
+	}
+	if a.DependencyMap == nil {
+		a.DependencyMap = map[string][]string{}
+	}
+}
+
+func (a *Argument) default_() string {
+	return a.DefaultValue
+}
+
+func (a *Argument) isPositional() bool {
+	return a.Position != nil
+}
+
+func (a *Argument) short() string {
+	if a.Short == "" {
+		return ""
+	}
+
+	return "or -" + a.Short
+}
+
+func (a *Argument) required() string {
+	requiredOrOptional := "optional"
+	if a.Required {
+		requiredOrOptional = "required"
+	} else if a.RequiredIf != nil {
+		requiredOrOptional = "conditional"
+	}
+
+	return "(" + requiredOrOptional + ")"
+}
+
+func (a *Argument) description() string {
+	d := a.default_()
+	if d != "" {
+		return fmt.Sprintf("\"%s\" (defaults to: %s)", a.Description, d)
+
+	}
+
+	return fmt.Sprintf("\"%s\"", a.Description)
+}

--- a/argument_config_funcs.go
+++ b/argument_config_funcs.go
@@ -5,43 +5,8 @@ import (
 	"regexp"
 
 	"github.com/napalu/goopt/types"
+	"github.com/napalu/goopt/util"
 )
-
-// NewArg convenience initialization method to configure flags
-func NewArg(configs ...ConfigureArgumentFunc) *Argument {
-	argument := &Argument{}
-	for _, config := range configs {
-		config(argument, nil)
-	}
-
-	return argument
-}
-
-// Set configures the Argument instance with the provided ConfigureArgumentFunc(s),
-// and returns an error if a configuration results in an error.
-//
-// Usage example:
-//
-//	arg := &Argument{}
-//	err := arg.Set(
-//	    WithDescription("example argument"),
-//	    WithType(Standalone),
-//	    IsRequired,
-//	)
-//	if err != nil {
-//	    // handle error
-//	}
-func (a *Argument) Set(configs ...ConfigureArgumentFunc) error {
-	a.ensureInit()
-	var err error
-	for _, config := range configs {
-		config(a, &err)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 // WithShortFlag represents the short form of a flag. Since by default and design, no max length is enforced,
 // the "short" flag can be looked at as an alternative to using the long name. I use it as a moniker. The short flag
@@ -190,27 +155,12 @@ func WithAcceptedValues(values []types.PatternValue) ConfigureArgumentFunc {
 }
 
 // WithPosition sets a position requirement for the argument
-func WithPosition(pos types.PositionType) ConfigureArgumentFunc {
+func WithPosition(idx int) ConfigureArgumentFunc {
 	return func(argument *Argument, err *error) {
-		// Validate position type
-		if pos != types.AtStart && pos != types.AtEnd {
-			*err = fmt.Errorf("invalid position type: %d", pos)
-			return
-		}
-		argument.Position = &pos
-	}
-}
-
-// WithRelativeIndex sets the index for ordered positional arguments
-func WithRelativeIndex(idx int) ConfigureArgumentFunc {
-	return func(argument *Argument, err *error) {
-		// Validate index is non-negative
 		if idx < 0 {
 			*err = fmt.Errorf("positional index must be non-negative, got: %d", idx)
 			return
 		}
-		argument.RelativeIndex = &idx
+		argument.Position = util.NewOfType(idx)
 	}
 }
-
-// TODO explore adding WithValidation to positional arguments

--- a/argument_config_funcs_test.go
+++ b/argument_config_funcs_test.go
@@ -236,49 +236,6 @@ func TestArgument_ConfigFuncs(t *testing.T) {
 	}
 }
 
-func TestWithPosition(t *testing.T) {
-	tests := []struct {
-		name        string
-		position    types.PositionType
-		wantErr     bool
-		errContains string
-	}{
-		{
-			name:     "valid AtStart",
-			position: types.AtStart,
-			wantErr:  false,
-		},
-		{
-			name:     "valid AtEnd",
-			position: types.AtEnd,
-			wantErr:  false,
-		},
-		{
-			name:        "invalid position type",
-			position:    types.PositionType(99),
-			wantErr:     true,
-			errContains: "invalid position type",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			arg := &Argument{}
-			var err error
-			WithPosition(tt.position)(arg, &err)
-
-			if tt.wantErr {
-				assert.NotNil(t, err)
-				assert.Contains(t, err.Error(), tt.errContains)
-			} else {
-				assert.Nil(t, err)
-				assert.NotNil(t, arg.Position)
-				assert.Equal(t, tt.position, *arg.Position)
-			}
-		})
-	}
-}
-
 func TestWithPositionalIndex(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -308,15 +265,17 @@ func TestWithPositionalIndex(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			arg := &Argument{}
 			var err error
-			WithRelativeIndex(tt.index)(arg, &err)
+			WithPosition(tt.index)(arg, &err)
 
 			if tt.wantErr {
 				assert.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.errContains)
 			} else {
 				assert.Nil(t, err)
-				assert.NotNil(t, arg.RelativeIndex)
-				assert.Equal(t, tt.index, *arg.RelativeIndex)
+				assert.NotNil(t, arg.Position)
+				if arg.Position != nil {
+					assert.Equal(t, tt.index, *arg.Position)
+				}
 			}
 		})
 	}

--- a/argument_test.go
+++ b/argument_test.go
@@ -1,0 +1,22 @@
+package goopt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArgument_String(t *testing.T) {
+	arg := NewArg(
+		WithDescription("test desc"),
+		WithShortFlag("t"),
+		WithDefaultValue("default"),
+		SetRequired(true),
+	)
+
+	str := arg.String()
+	assert.Contains(t, str, "test desc", "string representation should contain description")
+	assert.Contains(t, str, "-t", "string representation should contain short flag")
+	assert.Contains(t, str, "default", "string representation should contain default value")
+	assert.Contains(t, str, "required", "string representation should indicate required status")
+}

--- a/command_config_funcs_test.go
+++ b/command_config_funcs_test.go
@@ -1,0 +1,23 @@
+package goopt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommand_WithOverwriteSubcommands(t *testing.T) {
+	cmd := NewCommand(
+		WithName("parent"),
+		WithSubcommands(
+			NewCommand(WithName("old")),
+		),
+	)
+
+	WithOverwriteSubcommands(
+		NewCommand(WithName("new")),
+	)(cmd)
+
+	assert.Equal(t, 1, len(cmd.Subcommands), "should have one subcommand")
+	assert.Equal(t, "new", cmd.Subcommands[0].Name, "should have overwritten subcommand")
+}

--- a/definitions.go
+++ b/definitions.go
@@ -116,26 +116,6 @@ type PositionalArgument struct {
 	Argument *Argument // Reference to the argument definition, if this was bound
 }
 
-// Argument defines a command-line Flag
-type Argument struct {
-	Description    string
-	TypeOf         types.OptionType
-	Required       bool
-	RequiredIf     RequiredIfFunc
-	PreFilter      FilterFunc
-	PostFilter     FilterFunc
-	AcceptedValues []types.PatternValue
-	DependsOn      []string // Deprecated: use DependencyMap instead - will be removed in v2.0.0
-	OfValue        []string // Deprecated: use DependencyMap instead - will be removed in v2.0.0
-	DependencyMap  map[string][]string
-	Secure         types.Secure
-	Short          string
-	DefaultValue   string
-	Capacity       int                 // For slices, the capacity of the slice, ignored for other types
-	Position       *types.PositionType // nil means no position requirement
-	RelativeIndex  *int                // Required if Position is set, determines order within position group
-}
-
 // Command defines commands and sub-commands
 type Command struct {
 	Name        string

--- a/docs/guides/struct-tags.md
+++ b/docs/guides/struct-tags.md
@@ -31,7 +31,7 @@ type Config struct {
 | `secure` | For password input | `secure:true\|false` |
 | `prompt` | Prompt text for secure input | `prompt:Password:` |
 | `capacity` | Slice capacity for nested structs | `capacity:3` |
-| `pos` | Position requirements | `pos:{at:start,idx:0}` |
+| `pos` | Position requirements | `pos:0` |
 | `accepted` | Accepted values/patterns | `accepted:{pattern:json\|yaml,desc:Format}` |
 | `depends` | Flag dependencies | `depends:{flag:output,values:[json]}` |
 
@@ -42,22 +42,14 @@ The `pos` tag allows specifying position requirements for arguments:
 ```go
 type Config struct {
     // Must be first argument
-    Source string `goopt:"name:source;pos:{at:start,idx:0}"`
-    
+    Source string `goopt:"name:source;pos:0"`
+        // Second argument from start
+    Profile string `goopt:"name:profile;pos:1"`
     // Must be last argument
-    Dest string `goopt:"name:dest;pos:{at:end,idx:0}"`
+    Dest string `goopt:"name:dest;pos:2"`
     
-    // Second argument from start
-    Profile string `goopt:"name:profile;pos:{at:start,idx:1}"`
 }
 ```
-
-### Position Types
-- `start`: Argument must appear before flags/commands
-- `end`: Argument must appear after flags/commands
-
-### Index
-The optional `idx` field specifies relative position when multiple arguments share the same position type.
 
 ## Complex Tag Examples
 

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,13 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/iancoleman/strcase v0.3.0
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/term v0.24.0
+	golang.org/x/term v0.28.0
+	golang.org/x/text v0.21.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.25.0 // indirect
+	golang.org/x/sys v0.29.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,10 +16,12 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
-golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.24.0 h1:Mh5cbb+Zk2hqqXNO7S1iTjEphVL+jb8ZWaqh/g+JWkM=
-golang.org/x/term v0.24.0/go.mod h1:lOBK/LVxemqiMij05LGJ0tzNr8xlmwBRJ81PX6wVLH8=
+golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
+golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.28.0 h1:/Ts8HFuMR2E6IP/jlo7QVLZHggjKQbhu/7H0LJFr3Gg=
+golang.org/x/term v0.28.0/go.mod h1:Sw/lC2IAUZ92udQNf3WodGtn4k/XoLyZoh8v/8uiwek=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/parse/tag.go
+++ b/parse/tag.go
@@ -21,7 +21,7 @@ const (
 	errEmptyInput        = "empty %s"
 	errMalformedBraces   = "malformed braces in: %s"
 	errUnmatchedBrackets = "unmatched brackets in: %s"
-	errInvalidFormat     = "invalid format"
+	errInvalidFormat     = "invalid format in: %s"
 	errEmptyKey          = "empty key in: %s"
 	errMissingValue      = "missing or empty %s in: %s"
 	errDuplicateFlag     = "duplicate flag: %s"
@@ -249,12 +249,11 @@ func UnmarshalTagFormat(tag string, field reflect.StructField) (*types.TagConfig
 			}
 			config.Capacity = cap
 		case "pos":
-			posData, err := Position(fmt.Sprintf("pos:%s", value))
+			posData, err := Position(value)
 			if err != nil {
 				return nil, fmt.Errorf("invalid position in field %s: %w", field.Name, err)
 			}
-			config.Position = posData.At
-			config.RelativeIndex = posData.Idx
+			config.Position = &posData.Index
 		default:
 			return nil, fmt.Errorf("unrecognized key '%s' in field %s", key, field.Name)
 		}

--- a/parse/tag_pos_test.go
+++ b/parse/tag_pos_test.go
@@ -4,8 +4,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/napalu/goopt/types"
 )
 
 func TestPosition(t *testing.T) {
@@ -17,46 +15,26 @@ func TestPosition(t *testing.T) {
 		errString string
 	}{
 		{
-			name:  "start position with index",
-			input: "pos:{at:start,idx:0}",
-			want: &PositionData{
-				At:  ptr(types.AtStart),
-				Idx: ptr(0),
-			},
+			name:  "simple position",
+			input: "0",
+			want:  &PositionData{Index: 0},
 		},
 		{
-			name:  "end position without index",
-			input: "pos:{at:end}",
-			want: &PositionData{
-				At:  ptr(types.AtEnd),
-				Idx: nil,
-			},
-		},
-		{
-			name:  "only index",
-			input: "pos:{at:,idx:1}",
-			want: &PositionData{
-				At:  nil,
-				Idx: ptr(1),
-			},
-		},
-		{
-			name:      "invalid position type",
-			input:     "pos:{at:middle,idx:0}",
-			wantErr:   true,
-			errString: "invalid position type",
+			name:  "legacy format",
+			input: "{idx:0}",
+			want:  &PositionData{Index: 0},
 		},
 		{
 			name:      "negative index",
-			input:     "pos:{at:start,idx:-1}",
+			input:     "-1",
 			wantErr:   true,
 			errString: "index must be non-negative",
 		},
 		{
-			name:      "malformed braces",
-			input:     "pos:at:start,idx:0}",
+			name:      "invalid format",
+			input:     "invalid",
 			wantErr:   true,
-			errString: "malformed braces",
+			errString: "invalid index value",
 		},
 		{
 			name:      "empty input",
@@ -65,155 +43,20 @@ func TestPosition(t *testing.T) {
 			errString: "empty position",
 		},
 		{
-			name:      "invalid format",
-			input:     "pos:{at=start}",
-			wantErr:   true,
-			errString: "invalid format",
+			name:  "whitespace handling",
+			input: "  42  ",
+			want:  &PositionData{Index: 42},
 		},
 		{
-			name:  "empty position type with index",
-			input: "pos:{at:,idx:1}",
-			want: &PositionData{
-				At:  nil,
-				Idx: ptr(1),
-			},
+			name:  "legacy whitespace handling",
+			input: "  {  idx  :  42  }  ",
+			want:  &PositionData{Index: 42},
 		},
 		{
-			name:  "empty position type with spaces and index",
-			input: "pos:{at: ,idx:1}",
-			want: &PositionData{
-				At:  nil,
-				Idx: ptr(1),
-			},
-		},
-		{
-			name:  "only empty position type",
-			input: "pos:{at:}",
-			want: &PositionData{
-				At:  nil,
-				Idx: nil,
-			},
-		},
-		{
-			name:  "excessive whitespace",
-			input: "  pos:{  at  :  start  ,  idx  :  0  }  ",
-			want: &PositionData{
-				At:  ptr(types.AtStart),
-				Idx: ptr(0),
-			},
-		},
-		{
-			name:  "newlines in input",
-			input: "pos:{\nat:start,\nidx:0\n}",
-			want: &PositionData{
-				At:  ptr(types.AtStart),
-				Idx: ptr(0),
-			},
-		},
-		{
-			name:  "large index value",
-			input: "pos:{at:end,idx:999999}",
-			want: &PositionData{
-				At:  ptr(types.AtEnd),
-				Idx: ptr(999999),
-			},
-		},
-		{
-			name:      "index overflow",
-			input:     "pos:{at:end,idx:9999999999999999999}",
-			wantErr:   true,
-			errString: "invalid index value",
-		},
-		{
-			name:      "missing colon",
-			input:     "pos:{at start,idx:0}",
+			name:      "malformed legacy format",
+			input:     "{idx:0",
 			wantErr:   true,
 			errString: "malformed braces",
-		},
-		{
-			name:  "extra fields",
-			input: "pos:{at:start,idx:0,extra:value}",
-			want: &PositionData{
-				At:  ptr(types.AtStart),
-				Idx: ptr(0),
-			},
-		},
-		{
-			name:  "duplicate fields",
-			input: "pos:{at:start,at:end,idx:0}",
-			want: &PositionData{
-				At:  ptr(types.AtEnd),
-				Idx: ptr(0),
-			},
-		},
-		{
-			name:  "empty braces",
-			input: "pos:{}",
-			want:  &PositionData{},
-		},
-		{
-			name:      "missing closing brace",
-			input:     "pos:{at:start",
-			wantErr:   true,
-			errString: "malformed braces",
-		},
-		{
-			name:      "missing opening brace",
-			input:     "pos:at:start}",
-			wantErr:   true,
-			errString: "malformed braces",
-		},
-		{
-			name:  "case insensitive START",
-			input: "pos:{at:START,idx:0}",
-			want: &PositionData{
-				At:  ptr(types.AtStart),
-				Idx: ptr(0),
-			},
-		},
-		{
-			name:  "case insensitive END",
-			input: "pos:{at:EnD}",
-			want: &PositionData{
-				At:  ptr(types.AtEnd),
-				Idx: nil,
-			},
-		},
-		{
-			name:      "invalid position with number",
-			input:     "pos:{at:start1}",
-			wantErr:   true,
-			errString: "invalid position type",
-		},
-		{
-			name:      "invalid position with special chars",
-			input:     "pos:{at:start@end}",
-			wantErr:   true,
-			errString: "invalid position type",
-		},
-		{
-			name:  "multiple idx values",
-			input: "pos:{at:start,idx:0,idx:1}",
-			want: &PositionData{
-				At:  ptr(types.AtStart),
-				Idx: ptr(1),
-			},
-		},
-		{
-			name:  "multiple at values",
-			input: "pos:{at:start,at:end}",
-			want: &PositionData{
-				At:  ptr(types.AtEnd),
-				Idx: nil,
-			},
-		},
-		{
-			name:  "idx without at",
-			input: "pos:{idx:0}",
-			want: &PositionData{
-				At:  nil,
-				Idx: ptr(0),
-			},
 		},
 	}
 
@@ -239,118 +82,4 @@ func TestPosition(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestPositionType_String(t *testing.T) {
-	tests := []struct {
-		name string
-		p    types.PositionType
-		want string
-	}{
-		{
-			name: "start position",
-			p:    types.AtStart,
-			want: "start",
-		},
-		{
-			name: "end position",
-			p:    types.AtEnd,
-			want: "end",
-		},
-		{
-			name: "unknown position",
-			p:    types.PositionType(999),
-			want: "unknown",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.p.String(); got != tt.want {
-				t.Errorf("PositionType.String() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestParsePositionType(t *testing.T) {
-	tests := []struct {
-		name      string
-		input     string
-		want      types.PositionType
-		wantErr   bool
-		errString string
-	}{
-		{
-			name:  "start lowercase",
-			input: "start",
-			want:  types.AtStart,
-		},
-		{
-			name:  "end lowercase",
-			input: "end",
-			want:  types.AtEnd,
-		},
-		{
-			name:  "start uppercase",
-			input: "START",
-			want:  types.AtStart,
-		},
-		{
-			name:  "end uppercase",
-			input: "END",
-			want:  types.AtEnd,
-		},
-		{
-			name:  "start mixed case",
-			input: "StArT",
-			want:  types.AtStart,
-		},
-		{
-			name:  "empty string",
-			input: "",
-			want:  0,
-		},
-		{
-			name:  "whitespace only",
-			input: "   ",
-			want:  0,
-		},
-		{
-			name:      "invalid position",
-			input:     "middle",
-			wantErr:   true,
-			errString: "invalid position type",
-		},
-		{
-			name:      "invalid with spaces",
-			input:     "  invalid  ",
-			wantErr:   true,
-			errString: "invalid position type",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := parsePositionType(tt.input)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("parsePositionType() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if tt.wantErr {
-				if !strings.Contains(err.Error(), tt.errString) {
-					t.Errorf("parsePositionType() error = %v, want error containing %v", err, tt.errString)
-				}
-				return
-			}
-			if got != tt.want {
-				t.Errorf("parsePositionType() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-// Helper function to create pointers
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/parse/tag_test.go
+++ b/parse/tag_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/napalu/goopt/types"
+	"github.com/napalu/goopt/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -191,43 +192,32 @@ func TestUnmarshalTagFormat_Position(t *testing.T) {
 	}{
 		{
 			name: "position with other tags",
-			tag:  "name:source;desc:Source file;pos:{at:start,idx:0};required:true",
-			want: &types.TagConfig{
-				Kind:          types.KindFlag,
-				Name:          "source",
-				Description:   "Source file",
-				Position:      ptr(types.AtStart),
-				RelativeIndex: ptr(0),
-				Required:      true,
-			},
-		},
-		{
-			name: "position only idx",
-			tag:  "pos:{idx:1}",
-			want: &types.TagConfig{
-				Kind:          types.KindFlag,
-				RelativeIndex: ptr(1),
-			},
-		},
-		{
-			name: "position with empty at",
-			tag:  "pos:{at:};required:true",
+			tag:  "pos:0;required:true",
 			want: &types.TagConfig{
 				Kind:     types.KindFlag,
+				Position: util.NewOfType(0),
 				Required: true,
 			},
 		},
 		{
-			name: "multiple position tags",
-			tag:  "pos:{at:start};pos:{at:end}", // Last one wins
+			name: "legacy position format",
+			tag:  "pos:{idx:0}",
 			want: &types.TagConfig{
 				Kind:     types.KindFlag,
-				Position: ptr(types.AtEnd),
+				Position: util.NewOfType(0),
 			},
 		},
 		{
-			name:    "invalid position type",
-			tag:     "pos:{at:middle}",
+			name: "multiple position tags",
+			tag:  "pos:0;pos:1", // Last one wins
+			want: &types.TagConfig{
+				Kind:     types.KindFlag,
+				Position: util.NewOfType(1),
+			},
+		},
+		{
+			name:    "invalid position",
+			tag:     "pos:-1",
 			wantErr: true,
 		},
 	}

--- a/parser_config_funcs_test.go
+++ b/parser_config_funcs_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/napalu/goopt/types"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func TestWithExecOnParse(t *testing.T) {
@@ -218,7 +220,7 @@ func TestWithNameConverters(t *testing.T) {
 				return strings.ReplaceAll(strings.ToUpper(s), "_", "")
 			},
 			cmdConverter: func(s string) string {
-				return strings.Title(strings.ToLower(s))
+				return cases.Title(language.Und).String(strings.ToLower(s))
 			},
 			expectedFlag: "USERNAME",
 			expectedCmd:  "Command",

--- a/types/common.go
+++ b/types/common.go
@@ -48,25 +48,6 @@ type KeyValue[K, V any] struct {
 	Value V
 }
 
-// PositionType defines where a positional argument must appear in the command line
-type PositionType int
-
-const (
-	AtStart PositionType = 1 // Must appear before any non-positional arguments
-	AtEnd   PositionType = 2 // Must appear after all non-positional arguments
-)
-
-// String returns the string representation of a PositionType
-func (p PositionType) String() string {
-	switch p {
-	case AtStart:
-		return "start"
-	case AtEnd:
-		return "end"
-	}
-	return "unknown"
-}
-
 // Secure set to Secure to true to solicit non-echoed user input from stdin.
 // If Prompt is empty a "password :" prompt will be displayed. Set to the desired value to override.
 type Secure struct {
@@ -97,8 +78,7 @@ type TagConfig struct {
 	AcceptedValues []PatternValue
 	DependsOn      map[string][]string
 	Capacity       int
-	Position       *PositionType
-	RelativeIndex  *int
+	Position       *int
 }
 
 // Describe a PatternValue (regular expression with a human-readable explanation of the pattern)

--- a/types/orderedmap/ordered_map.go
+++ b/types/orderedmap/ordered_map.go
@@ -132,6 +132,11 @@ func (o *OrderedMap[K, V]) Iterator() func() (*int, *K, V) {
 	}
 }
 
+// Len returns the number of elements in the OrderedMap
+func (o *OrderedMap[K, V]) Len() int {
+	return o.keys.Len()
+}
+
 // Delete will remove the key and its associated value.
 func (o *OrderedMap[K, V]) Delete(key K) {
 	e, exists := o.store[key]

--- a/types/orderedmap/ordered_map_test.go
+++ b/types/orderedmap/ordered_map_test.go
@@ -223,3 +223,45 @@ func TestOrderedMap(t *testing.T) {
 		assert.Equal(t, 2, val2)
 	})
 }
+
+func TestOrderedMap_Len(t *testing.T) {
+	tests := []struct {
+		name     string
+		elements map[string]int
+		want     int
+	}{
+		{
+			name:     "empty map",
+			elements: map[string]int{},
+			want:     0,
+		},
+		{
+			name: "single element",
+			elements: map[string]int{
+				"one": 1,
+			},
+			want: 1,
+		},
+		{
+			name: "multiple elements",
+			elements: map[string]int{
+				"one":   1,
+				"two":   2,
+				"three": 3,
+			},
+			want: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			om := NewOrderedMap[string, int]()
+			for k, v := range tt.elements {
+				om.Set(k, v)
+			}
+			if got := om.Len(); got != tt.want {
+				t.Errorf("Len() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/util/pointer.go
+++ b/util/pointer.go
@@ -24,3 +24,7 @@ func UnwrapType(t reflect.Type) reflect.Type {
 	}
 	return t
 }
+
+func NewOfType[T any](value T) *T {
+	return &value
+}

--- a/util/pointer_test.go
+++ b/util/pointer_test.go
@@ -20,12 +20,12 @@ func TestUnwrapValue(t *testing.T) {
 		},
 		{
 			name:    "single pointer",
-			input:   ptr("test"),
+			input:   NewOfType("test"),
 			wantErr: false,
 		},
 		{
 			name:    "double pointer",
-			input:   ptr(ptr("test")),
+			input:   NewOfType(NewOfType("test")),
 			wantErr: false,
 		},
 		{
@@ -64,12 +64,12 @@ func TestUnwrapType(t *testing.T) {
 		},
 		{
 			name:     "pointer to string",
-			input:    ptr("test"),
+			input:    NewOfType("test"),
 			expected: reflect.String,
 		},
 		{
 			name:     "pointer to pointer to string",
-			input:    ptr(ptr("test")),
+			input:    NewOfType(NewOfType("test")),
 			expected: reflect.String,
 		},
 	}
@@ -81,9 +81,4 @@ func TestUnwrapType(t *testing.T) {
 			assert.Equal(t, tt.expected, unwrapped.Kind())
 		})
 	}
-}
-
-// Helper function to create pointers
-func ptr[T any](v T) *T {
-	return &v
 }


### PR DESCRIPTION
* Replace complex Positional type with simple integer positions
* Update struct tag syntax from `pos:{idx:N}` to `pos:N`
* Remove AtStart/AtEnd position types
* Update documentation and tests
* Keep legacy format parsing for migration period

BREAKING CHANGE: Positional argument syntax has been simplified. Update struct tags from `pos:{idx:N}` to `pos:N`. The complex position types (AtStart, AtEnd) have been removed in favor of simple integer positions.

additional changes:
simplify argument printing