### PR TITLE
Implement struct-based callbacks

### DIFF
--- a/docs/_v2/whats-new.md
+++ b/docs/_v2/whats-new.md
@@ -55,6 +55,17 @@ The API has been cleaned up and modernized:
 - **Better documentation** with examples and usage patterns
 - **Simplified initialization** with functional options
 
+## Command Callbacks with Struct Context
+
+goopt v2 enhances command callbacks with the ability to access the original configuration struct:
+
+- **Type-safe struct access** - Command callbacks can retrieve the original struct used to initialize the parser
+- **Generic helper function** - Use `GetStructContextAs[T]()` to retrieve the struct in a type-safe manner
+- **Better code organization** - Separate command handling logic from CLI definition while maintaining type safety
+- **Package separation** - Organize command handlers in separate packages while maintaining access to configuration
+
+See [Command Callbacks with Struct Context]({{ site.baseurl }}/v2/guides/advanced-features/#command-callbacks-with-struct-context) for details on implementation and usage.
+
 ## Breaking Changes
 
 See the [Migration Guide]({{ site.baseurl }}/v2/migration/) for a complete list of breaking changes and how to update your code.

--- a/v2/README.md
+++ b/v2/README.md
@@ -18,6 +18,8 @@
 - **Secure Flags**: Enable secure, hidden input for sensitive information like passwords.
 - **Automatic Usage Generation**: Automatically generates usage documentation based on defined flags and commands.
 - **Positional Arguments**: Support for positional arguments with flexible position and index constraints.
+- **Command Callbacks**: Define executable functions tied to specific commands with access to the command context.
+- **Struct Context Access**: Access the original configuration struct from command callbacks, enabling better separation of concerns.
 
 
 ## Installation

--- a/v2/definitions.go
+++ b/v2/definitions.go
@@ -139,6 +139,7 @@ type Parser struct {
 	userI18n             *i18n.Bundle
 	currentLanguage      language.Tag
 	renderer             Renderer
+	structCtx            any
 }
 
 // CompletionData is used to store information for command line completion
@@ -160,10 +161,6 @@ type Renderer interface {
 	CommandDescription(c *Command) string
 	CommandUsage(c *Command) string
 }
-
-const (
-	FmtErrorWithString = "%w: %s"
-)
 
 type commandCallback struct {
 	callback  CommandFunc

--- a/v2/parser_config_funcs.go
+++ b/v2/parser_config_funcs.go
@@ -144,7 +144,7 @@ func WithEnvNameConverter(converter NameConversionFunc) ConfigureCmdLineFunc {
 	}
 }
 
-// WithI18n allows setting the language for the parser.
+// WithLanguage allows setting the language for the parser.
 func WithLanguage(lang language.Tag) ConfigureCmdLineFunc {
 	return func(cmdLine *Parser, err *error) {
 		cmdLine.i18n.SetDefaultLanguage(lang)


### PR DESCRIPTION
- GetStructCtx, GetStructContextAs[T] and HasStructCtx methods for basic access
- Documentation additions in README, getting-started and whats-new guides
- Comprehensive test coverage for all struct context functions