### PR TITLE
Fix InsertSlice handling for invalid indexes

### DIFF
--- a/internal/util/slice.go
+++ b/internal/util/slice.go
@@ -2,6 +2,13 @@ package util
 
 // InsertSlice inserts item(s) T at position pos and returns a slice
 func InsertSlice[T any](arr []T, pos int, element ...T) []T {
+	if pos < 0 {
+		pos = 0
+	}
+	if pos > len(arr) {
+		pos = len(arr)
+	}
+
 	return append(arr[:pos], append(element, arr[pos:]...)...)
 }
 

--- a/internal/util/slice_test.go
+++ b/internal/util/slice_test.go
@@ -48,6 +48,20 @@ func TestInsertSlice(t *testing.T) {
 			elements: []int{},
 			want:     []int{1, 2},
 		},
+		{
+			name:     "position negative",
+			arr:      []int{1, 2, 3},
+			pos:      -1,
+			elements: []int{0},
+			want:     []int{0, 1, 2, 3},
+		},
+		{
+			name:     "position beyond length",
+			arr:      []int{1, 2, 3},
+			pos:      10,
+			elements: []int{4},
+			want:     []int{1, 2, 3, 4},
+		},
 	}
 
 	for _, tt := range tests {

--- a/v2/internal/util/slice.go
+++ b/v2/internal/util/slice.go
@@ -2,6 +2,13 @@ package util
 
 // InsertSlice inserts item(s) T at position pos and returns a slice
 func InsertSlice[T any](arr []T, pos int, element ...T) []T {
+	if pos < 0 {
+		pos = 0
+	}
+	if pos > len(arr) {
+		pos = len(arr)
+	}
+
 	return append(arr[:pos], append(element, arr[pos:]...)...)
 }
 

--- a/v2/internal/util/slice_test.go
+++ b/v2/internal/util/slice_test.go
@@ -48,6 +48,20 @@ func TestInsertSlice(t *testing.T) {
 			elements: []int{},
 			want:     []int{1, 2},
 		},
+		{
+			name:     "position negative",
+			arr:      []int{1, 2, 3},
+			pos:      -1,
+			elements: []int{0},
+			want:     []int{0, 1, 2, 3},
+		},
+		{
+			name:     "position beyond length",
+			arr:      []int{1, 2, 3},
+			pos:      10,
+			elements: []int{4},
+			want:     []int{1, 2, 3, 4},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- guard against negative/out of range indexes in `InsertSlice`
- add tests covering edge cases for both v1 and v2 utilities

## Testing
- `go test ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_684e5c6658108320b2d2fe65d0e5dbab