### PR TITLE
(feat): support secure flags with environment variable overrides

### DIFF
--- a/docs/_v2/guides/03-defining-your-cli/01-struct-tags-reference.md
+++ b/docs/_v2/guides/03-defining-your-cli/01-struct-tags-reference.md
@@ -29,7 +29,7 @@ This table provides a complete reference to all available tags.
 | `type` | Overrides the inferred flag type. See `types.OptionType`. | `type:standalone` |
 | `required` | Makes a flag mandatory. The parser will error if it's missing. | `required:true` |
 | `default` | Provides a default value if the flag is not set. | `default:./output.txt` |
-| `secure` | Marks a flag as a secure input (e.g., for passwords). Hides user input. | `secure:true` |
+| `secure` | Marks a flag as a secure input (e.g., for passwords). Hides user input. When `SetEnvNameConverter` is configured, a matching environment variable will be used instead of prompting — useful for CI/CD and automation. CLI values are always ignored for security. | `secure:true` |
 | `prompt` | Sets the prompt text to display for a `secure` flag. | `prompt:"Enter password:"` |
 | `path` | Associates a flag with one or more comma-separated commands. | `path:"server start,server stop"` |
 | `pos` | Defines a flag as a positional argument at a specific index. | `pos:0` |

--- a/docs/_v2/guides/05-built-in-features/04-environment-config.md
+++ b/docs/_v2/guides/05-built-in-features/04-environment-config.md
@@ -44,6 +44,27 @@ func main() {
 
 With a converter set, an environment variable like `MYAPP_HOST=db.example.com` would automatically provide the value for a `--host` flag if it wasn't set on the command line.
 
+### Secure Flags and Environment Variables
+
+Flags marked with `secure:true` have special environment variable behavior. For security, values passed on the command line (e.g., `--password secret`) are always ignored — this prevents secrets from leaking via `ps aux` or shell history.
+
+However, when `SetEnvNameConverter` is configured, a matching environment variable will be used **instead of prompting**. This makes secure flags work in non-interactive environments like CI/CD pipelines, Docker containers, and automation scripts.
+
+```go
+parser.SetEnvNameConverter(strcase.ToLowerCamel)
+parser.SetEnvVarPrefix("MYAPP_")
+
+// With MYAPP_PASSWORD=s3cret in the environment:
+// - The user will NOT be prompted for the password
+// - The value "s3cret" is used directly
+// - Validators still run on the value
+
+// Without the env var set:
+// - The user is prompted interactively (existing behavior)
+```
+
+This works transparently with custom `env.Resolver` implementations (e.g., HashiCorp Vault, AWS SSM, Kubernetes secrets) — the resolver's `Environ()` output is scanned for matching variables.
+
 ---
 
 ## External Configuration (`ParseWithDefaults`)

--- a/v2/goopt_internal.go
+++ b/v2/goopt_internal.go
@@ -1386,7 +1386,6 @@ func (p *Parser) processValueFlag(currentArg string, next string, argument *Argu
 }
 
 func (p *Parser) processSecureFlag(name string, config *types.Secure) {
-	var prompt string
 	if !p.HasFlag(name) {
 		return
 	}
@@ -1394,32 +1393,71 @@ func (p *Parser) processSecureFlag(name string, config *types.Secure) {
 	if !config.IsSecure {
 		return
 	}
-	if config.Prompt == "" {
-		prompt = "password: "
-	} else {
-		prompt = config.Prompt
+
+	var pass string
+	var err error
+
+	// Try environment variable first (opt-in: only when envNameConverter is set)
+	if p.envNameConverter != nil {
+		if envValue := p.resolveSecureEnvVar(name); envValue != "" {
+			pass = envValue
+		}
 	}
-	if pass, err := input.GetSecureString(prompt, p.GetStderr(), p.GetTerminalReader()); err == nil {
-		// Get the argument info to run validators
-		if argInfo := p.getArgumentInfoByID(name); argInfo != nil && argInfo.Argument != nil {
-			// Run validators on secure value
-			if len(argInfo.Argument.Validators) > 0 {
-				for _, validator := range argInfo.Argument.Validators {
-					if err = validator(pass); err != nil {
-						p.addError(errs.WrapOnce(err, errs.ErrProcessingFlag, p.formatFlagForError(name)))
-						return
-					}
+
+	// No env value — prompt interactively
+	if pass == "" {
+		prompt := "password: "
+		if config.Prompt != "" {
+			prompt = config.Prompt
+		}
+		pass, err = input.GetSecureString(prompt, p.GetStderr(), p.GetTerminalReader())
+		if err != nil {
+			p.addError(errs.WrapOnce(err, errs.ErrSecureFlagExpectsValue, p.formatFlagForError(name)))
+			return
+		}
+	}
+
+	// Run validators on the value (regardless of source)
+	if flagInfo, found := p.acceptedFlags.Get(name); found && flagInfo.Argument != nil {
+		if len(flagInfo.Argument.Validators) > 0 {
+			for _, validator := range flagInfo.Argument.Validators {
+				if err = validator(pass); err != nil {
+					p.addError(errs.WrapOnce(err, errs.ErrProcessingFlag, p.formatFlagForError(name)))
+					return
 				}
 			}
 		}
-
-		err = p.registerSecureValue(name, pass)
-		if err != nil {
-			p.addError(errs.WrapOnce(err, errs.ErrProcessingFlag, p.formatFlagForError(name)))
-		}
-	} else {
-		p.addError(errs.WrapOnce(err, errs.ErrSecureFlagExpectsValue, p.formatFlagForError(name)))
 	}
+
+	// Register value
+	if err = p.registerSecureValue(name, pass); err != nil {
+		p.addError(errs.WrapOnce(err, errs.ErrProcessingFlag, p.formatFlagForError(name)))
+	}
+}
+
+// resolveSecureEnvVar checks if an environment variable matches the secure flag name.
+// Uses the same prefix/converter pattern as groupEnvVarsByCommand().
+func (p *Parser) resolveSecureEnvVar(name string) string {
+	baseName := splitPathFlag(name)[0]
+	for _, envEntry := range p.envResolver.Environ() {
+		kv := strings.SplitN(envEntry, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		varName := kv[0]
+		if p.envVarPrefix != "" && !strings.HasPrefix(varName, p.envVarPrefix) {
+			continue
+		}
+		stripped := strings.Replace(varName, p.envVarPrefix, "", 1)
+		if stripped == "" {
+			continue
+		}
+		converted := p.envNameConverter(stripped)
+		if converted == baseName {
+			return kv[1]
+		}
+	}
+	return ""
 }
 
 func (p *Parser) processSingleValue(next, key string, argument *Argument) (string, bool) {

--- a/v2/goopt_test.go
+++ b/v2/goopt_test.go
@@ -4837,6 +4837,193 @@ func TestParser_SecureFlagsInCommandContext(t *testing.T) {
 	assert.Empty(t, opts.ShouldNotBeAsked)
 }
 
+func TestParser_SecureFlagEnvOverride(t *testing.T) {
+	t.Run("env var set with envNameConverter — skips prompt", func(t *testing.T) {
+		type Opts struct {
+			Password string `goopt:"name:password;secure:true;prompt:Enter password"`
+		}
+		opts := &Opts{}
+		parser, err := NewParserFromStruct(opts)
+		require.NoError(t, err)
+
+		// Set up env resolver with matching var
+		mockEnv := &mockEnvResolver{
+			envVars: map[string]string{
+				"MYAPP_PASSWORD": "env-secret-123",
+			},
+		}
+		_ = parser.SetEnvResolver(mockEnv)
+		parser.SetEnvVarPrefix("MYAPP_")
+		parser.SetEnvNameConverter(func(s string) string {
+			return strings.ToLower(s)
+		})
+
+		// No terminal — would fail if it tried to prompt
+		parser.SetTerminalReader(&MockTerminal{
+			IsTerminalResult: false,
+		})
+		parser.SetStderr(&bytes.Buffer{})
+
+		ok := parser.Parse([]string{"--password"})
+		assert.True(t, ok, "Should succeed: env var provides the value")
+		assert.Equal(t, "env-secret-123", opts.Password)
+	})
+
+	t.Run("env var not set — falls back to prompt", func(t *testing.T) {
+		type Opts struct {
+			Password string `goopt:"name:password;secure:true;prompt:Enter password"`
+		}
+		opts := &Opts{}
+		parser, err := NewParserFromStruct(opts)
+		require.NoError(t, err)
+
+		// Empty env — no matching var
+		mockEnv := &mockEnvResolver{
+			envVars: map[string]string{},
+		}
+		_ = parser.SetEnvResolver(mockEnv)
+		parser.SetEnvVarPrefix("MYAPP_")
+		parser.SetEnvNameConverter(func(s string) string {
+			return strings.ToLower(s)
+		})
+
+		// Mock terminal that returns a password
+		parser.SetTerminalReader(&MockTerminal{
+			Password:         []byte("prompted-pass"),
+			IsTerminalResult: true,
+		})
+		parser.SetStderr(&bytes.Buffer{})
+
+		ok := parser.Parse([]string{"--password"})
+		assert.True(t, ok, "Should succeed: prompted for password")
+		assert.Equal(t, "prompted-pass", opts.Password)
+	})
+
+	t.Run("no envNameConverter — always prompts even if env var exists", func(t *testing.T) {
+		type Opts struct {
+			Password string `goopt:"name:password;secure:true;prompt:Enter password"`
+		}
+		opts := &Opts{}
+		parser, err := NewParserFromStruct(opts)
+		require.NoError(t, err)
+
+		// Env var IS set, but no envNameConverter — should not look it up
+		mockEnv := &mockEnvResolver{
+			envVars: map[string]string{
+				"MYAPP_PASSWORD": "env-secret",
+			},
+		}
+		_ = parser.SetEnvResolver(mockEnv)
+		parser.SetEnvVarPrefix("MYAPP_")
+		// Deliberately NOT setting envNameConverter
+
+		// Mock terminal returns different value
+		parser.SetTerminalReader(&MockTerminal{
+			Password:         []byte("terminal-pass"),
+			IsTerminalResult: true,
+		})
+		parser.SetStderr(&bytes.Buffer{})
+
+		ok := parser.Parse([]string{"--password"})
+		assert.True(t, ok, "Should succeed: prompted for password")
+		assert.Equal(t, "terminal-pass", opts.Password, "Should use prompted value, not env var")
+	})
+
+	t.Run("env var set with validator — validator runs on env value", func(t *testing.T) {
+		parser := NewParser()
+		_ = parser.AddFlag("password", NewArg(
+			WithSecurePrompt("Enter password"),
+			WithValidators(func(value string) error {
+				if len(value) < 8 {
+					return fmt.Errorf("password must be at least 8 characters")
+				}
+				return nil
+			}),
+		))
+
+		mockEnv := &mockEnvResolver{
+			envVars: map[string]string{
+				"APP_PASSWORD": "short", // too short — should fail validation
+			},
+		}
+		_ = parser.SetEnvResolver(mockEnv)
+		parser.SetEnvVarPrefix("APP_")
+		parser.SetEnvNameConverter(func(s string) string {
+			return strings.ToLower(s)
+		})
+		parser.SetTerminalReader(&MockTerminal{IsTerminalResult: false})
+		parser.SetStderr(&bytes.Buffer{})
+
+		ok := parser.Parse([]string{"--password"})
+		assert.False(t, ok, "Should fail: env value too short for validator")
+
+		errStr := ""
+		for _, e := range parser.GetErrors() {
+			errStr += e.Error() + "\n"
+		}
+		assert.Contains(t, errStr, "at least 8 characters")
+	})
+
+	t.Run("empty env var — still prompts", func(t *testing.T) {
+		type Opts struct {
+			Password string `goopt:"name:password;secure:true"`
+		}
+		opts := &Opts{}
+		parser, err := NewParserFromStruct(opts)
+		require.NoError(t, err)
+
+		mockEnv := &mockEnvResolver{
+			envVars: map[string]string{
+				"MYAPP_PASSWORD": "", // empty value
+			},
+		}
+		_ = parser.SetEnvResolver(mockEnv)
+		parser.SetEnvVarPrefix("MYAPP_")
+		parser.SetEnvNameConverter(func(s string) string {
+			return strings.ToLower(s)
+		})
+
+		parser.SetTerminalReader(&MockTerminal{
+			Password:         []byte("prompted-pass"),
+			IsTerminalResult: true,
+		})
+		parser.SetStderr(&bytes.Buffer{})
+
+		ok := parser.Parse([]string{"--password"})
+		assert.True(t, ok)
+		assert.Equal(t, "prompted-pass", opts.Password, "Empty env var should fall through to prompt")
+	})
+
+	t.Run("secure flag in command context with env override", func(t *testing.T) {
+		type ServerOpts struct {
+			ApiKey string `goopt:"name:api-key;secure:true;prompt:Enter API key"`
+		}
+		type Opts struct {
+			Server ServerOpts `goopt:"kind:command"`
+		}
+		opts := &Opts{}
+		parser, err := NewParserFromStruct(opts)
+		require.NoError(t, err)
+
+		mockEnv := &mockEnvResolver{
+			envVars: map[string]string{
+				"APP_API_KEY": "env-api-key-value",
+			},
+		}
+		_ = parser.SetEnvResolver(mockEnv)
+		parser.SetEnvVarPrefix("APP_")
+		parser.SetEnvNameConverter(func(s string) string {
+			return strings.ToLower(strings.ReplaceAll(s, "_", "-"))
+		})
+		parser.SetTerminalReader(&MockTerminal{IsTerminalResult: false})
+		parser.SetStderr(&bytes.Buffer{})
+
+		ok := parser.Parse([]string{"server", "--api-key"})
+		assert.True(t, ok, "Should succeed: env var provides the value for command-scoped secure flag")
+		assert.Equal(t, "env-api-key-value", opts.Server.ApiKey)
+	})
+}
+
 func TestParser_ComplexPositionalArguments(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
- Add support for secure flags to use matching environment variables when `SetEnvNameConverter` is configured.