### PR TITLE
fix(i18n): fix translation inheritance

### DIFF
--- a/docs/_v2/guides/02-core-concepts.md
+++ b/docs/_v2/guides/02-core-concepts.md
@@ -98,6 +98,30 @@ Flags in `goopt` can be global or tied to a specific command. This is a core con
 
 For example, in a command like `myapp --verbose service start`, the `--verbose` flag (if global) is available to and can be checked by the logic for both the `service` and `start` commands.
 
+## Design Principles
+
+A handful of invariants explain *why* `goopt` behaves the way it does. Knowing them up front means a surprising behavior reads as a deliberate choice rather than a bug — and they're the rules the rest of the guides build on.
+
+*   **Diagnostics are collected, not thrown.** `Parse` doesn't stop at the first problem — it gathers every error and warning so the user can fix them all in one pass. You inspect them afterwards via `parser.GetErrors()` and `parser.GetWarnings()` and decide what is fatal. This is why a "required flag missing" doesn't abort parsing of the rest of the command line.
+
+*   **Two audiences, two moments.** *Contradictory declarations* — a `mutex`/`exactlyone` group with a single member, or a flag that is both `required` and has a `default` — are caught at **construction** (`NewParserFromStruct` / `AddFlag` return an error). *Invalid user input* is caught at **parse** time, where messages are end-user-facing and translatable. Developer mistakes and user mistakes surface at different moments, to different people.
+
+*   **`required` means "the user must supply it."** It is about explicit provision, not "must end up with a value" — and *supply* spans every input channel (command line, environment, or config), not just the command line. A flag therefore cannot be both `required` and have a `default`: that's a contradiction (a default means it is never actually missing), and `goopt` rejects it at construction. (For the same family of reasons, a `default` on a `mutex`/`exactlyone` member is also rejected — a fallback value for a mutually-exclusive option is meaningless.) When you want a fallback value, read it with `GetOrDefault()`, which always returns the configured default.
+
+*   **Secure (prompted) flags stay automation-friendly.** A `secure` flag normally reads hidden input from an interactive prompt. But when an env converter is set and the matching variable is present, the value is taken from the environment *in lieu of prompting* — so a `required` secure flag (a password, an API token) behaves the same in an interactive shell and in CI/CD, where no prompt is possible. The environment value counts as supplied; nothing silently falls back to a default.
+
+*   **Defaults are trusted; user input is validated.** A `default:` value is *not* run through the flag's validators — you, the developer, control it. A value supplied by the user (command line, env, or config) *is* validated. Validators guard untrusted input, not your own defaults.
+
+*   **Flags inherit to subcommands; positional arguments do not.** Flags are name-keyed, so a parent's flag is unambiguously available to its children (see [Flag Scopes & Inheritance](#flag-scopes--inheritance) above). Positionals are index-keyed, so inheriting them across command levels would risk silently binding a value to the wrong slot — they stay [command-local]({{ site.baseurl }}/v2/guides/03-defining-your-cli/04-positional-arguments/) by design.
+
+*   **Translation completeness is enforced, not optional.** Every loaded locale must define every message key; a missing key panics at load rather than silently falling back to English. This keeps translations honest — an incomplete locale fails loudly during development instead of shipping half-translated. (Only `en`, `de`, and `fr` load by default; other locales are opt-in.)
+
+*   **A field's tag decides what it is.** In the struct-first approach a field with a flag tag (`desc`, `default`, `short`, …) becomes a **flag**, a field tagged `kind:command` becomes a **command**, and a field with an empty or absent tag is **neither** (ignored). Give a flag field at least a `desc` or a `default` so `goopt` registers it.
+
+*   **You can tell a supplied value from a default.** `HasFlag(name)` returns `true` only when a value was *explicitly* supplied (command line, env, or config) and `false` when the flag fell back to its default — even when the supplied value happens to equal the default. Reach for it when "did the user actually set this?" matters.
+
+*   **Precedence and build style are settled choices, not accidents.** Value [precedence](#configuration-precedence) is fixed (`default < env < config < command line`), and the [three build styles](#the-three-ways-to-build-your-cli) are equivalent — struct, programmatic, and hybrid all produce the same parser, so you pick the ergonomics, not the capabilities.
+
 ## Batteries-Included Features
 
 Finally, `goopt` is designed to reduce boilerplate by providing powerful features out of the box.

--- a/docs/_v2/guides/03-defining-your-cli/01-struct-tags-reference.md
+++ b/docs/_v2/guides/03-defining-your-cli/01-struct-tags-reference.md
@@ -32,7 +32,7 @@ This table provides a complete reference to all available tags.
 | `secure` | Marks a flag as a secure input (e.g., for passwords). Hides user input. When `SetEnvNameConverter` is configured, a matching environment variable will be used instead of prompting — useful for CI/CD and automation. CLI values are always ignored for security. | `secure:true` |
 | `prompt` | Sets the prompt text to display for a `secure` flag. | `prompt:"Enter password:"` |
 | `path` | Associates a flag with one or more comma-separated commands. | `path:"server start,server stop"` |
-| `pos` | Defines a flag as a positional argument at a specific index. | `pos:0` |
+| `pos` | Defines a flag as a positional argument at a specific index. Positionals are **command-local** (not inherited by subcommands) — see [Positional Arguments]({{ site.baseurl }}/v2/guides/03-defining-your-cli/04-positional-arguments/). | `pos:0` |
 | `capacity` | For slices of nested structs, pre-allocates the slice capacity. | `capacity:5` |
 | `validators` | A comma-separated list of validation rules to apply. See [Validation]({{ site.baseurl }}/v2/guides/04-advanced-features/01-validation/). | `validators:"email,minlength(8)"` |
 | `depends` | Defines a dependency where this flag requires another flag to be present with a specific value. | `depends:"{flag:format,values:[json]}"` |

--- a/docs/_v2/guides/03-defining-your-cli/04-positional-arguments.md
+++ b/docs/_v2/guides/03-defining-your-cli/04-positional-arguments.md
@@ -76,6 +76,25 @@ type Config struct {
 }
 ```
 
+### Positionals and Commands
+
+Positional arguments are **command-local**: a positional declared on a command binds only when **that exact command** is invoked. Unlike named flags — which are inherited by subcommands — positionals are **not** inherited. A positional declared on a parent command is not bound when a subcommand is invoked.
+
+This is by design. Flags are name-keyed and therefore unambiguous to inherit, but positionals are index-keyed: inheriting them across command levels would let a parent's `pos:0` and a subcommand's `pos:0` collide, silently mis-binding a value, and would let a subcommand swallow stray arguments that should otherwise raise an "unknown argument" error. Keeping positionals command-local keeps binding predictable.
+
+If you need the same value across several subcommands, either declare the positional on each subcommand, or use a **named flag** (which *does* inherit):
+
+```go
+type Config struct {
+    Db struct {
+        Name    string `goopt:"name:name"`        // a flag inherits into every subcommand
+        Migrate struct{} `goopt:"kind:command"`
+        Backup  struct{} `goopt:"kind:command"`
+    } `goopt:"kind:command"`
+}
+// myapp db migrate --name prod   and   myapp db backup --name prod
+```
+
 ## Mixing Positional Arguments and Named Flags
 
 goopt seamlessly handles command lines that contain both positional arguments (defined with `pos:N`) and named flags (e.g., `--verbose`, `--output file`).
@@ -157,7 +176,7 @@ type PositionalArgument struct {
 goopt provides clear error messages for position violations:
 
 ```go
-if !parser.Parse(os.Args[1:]) {
+if !parser.Parse(os.Args) {
     for _, err := range parser.GetErrors() {
         fmt.Println("Error:", err)
         // Example: "Error: missing required positional argument 'source' at position 0"

--- a/docs/_v2/guides/04-advanced-features/05-contracts.md
+++ b/docs/_v2/guides/04-advanced-features/05-contracts.md
@@ -184,6 +184,15 @@ Contracts distinguish **developer mistakes** from **user mistakes**:
   error), keeping it out of end-user output. When you add contracts programmatically after the
   parser exists, the same guard runs on the next `Parse`.
 
+> **No `default` on a `mutex`/`exactlyone` member.** A fallback value has no coherent meaning
+> for an option you select *among others*: it can neither count as a choice (it would
+> permanently win the group) nor be ignored (it would demand a selection while already holding a
+> value). So `default` on a `mutex`/`exactlyone` flag is **rejected at construction**. "Pick one
+> *with* a default" is not a group at all — it's a single value flag: `--format` with
+> `default:"json"` and `validators:isoneof(json,yaml,table)`. Use a group only for *separate*,
+> heterogeneous flags (e.g. `--from-file` / `--from-url` / `--from-stdin`), where a per-member
+> default doesn't apply.
+
 ## Contracts and Commands
 
 Contracts on **command-scoped flags** are evaluated per invoked command:

--- a/docs/_v2/guides/04-advanced-features/05-contracts.md
+++ b/docs/_v2/guides/04-advanced-features/05-contracts.md
@@ -184,6 +184,39 @@ Contracts distinguish **developer mistakes** from **user mistakes**:
   error), keeping it out of end-user output. When you add contracts programmatically after the
   parser exists, the same guard runs on the next `Parse`.
 
+## Contracts and Commands
+
+Contracts on **command-scoped flags** are evaluated per invoked command:
+
+- A contract on a flag owned by a command applies **only when that command (or one of its
+  subcommands) is invoked**. Running `export` never triggers a `sync` flag's contract, and
+  vice-versa. **Global flags** always participate.
+- Target names resolve **within the declaring flag's command scope** first, then fall back to
+  global. So `contract:requires(group-pattern)` on an `export` flag resolves to `export`'s
+  `--group-pattern`, not a same-named flag elsewhere.
+- Group labels are **scoped per command**: a `mutex(mode)` group in `export` is independent of a
+  `mutex(mode)` group in `sync` — including the build-time singleton-group guard.
+
+```go
+type CLI struct {
+    Export struct {
+        Group        string `goopt:"contract:exactlyone(selector)"`
+        GroupPattern string `goopt:"contract:exactlyone(selector)"`
+        Search       bool   `goopt:"contract:exactlyone(selector)"`
+        Combined     bool   `goopt:"contract:requires(group-pattern)"`
+    } `goopt:"kind:command"`
+    Sync struct {
+        SourceGroup   string `goopt:"contract:exactlyone(source)"`
+        SourcePattern string `goopt:"contract:exactlyone(source)"`
+        FullReconcile bool   `goopt:"contract:requires(prune)"`
+        Prune         bool   `goopt:""`
+    } `goopt:"kind:command"`
+}
+```
+
+Here `myapp export` enforces exactly one of `export`'s selectors and `--combined`'s requirement,
+while `sync`'s `exactlyone(source)` and `requires(prune)` stay dormant until `myapp sync` runs.
+
 ## Internationalization
 
 All contract messages are fully translatable through the standard i18n system. The user-facing

--- a/v2/contract.go
+++ b/v2/contract.go
@@ -97,6 +97,19 @@ func parseContract(spec string) (Contract, error) {
 	}
 }
 
+// contractGroupKey identifies a mutex/exactlyone group. A group is scoped to its
+// owning command, so a same-named group in another command is independent. This is
+// the single definition of "what a group is", shared by the build-time singleton
+// guard (validateContractGroups) and the runtime evaluation (validateContracts) —
+// keeping the two in lockstep so a group can never mean one thing at build time and
+// another at parse time.
+type contractGroupKey struct{ cmd, label string }
+
+// conflictPair identifies an unordered pair of conflicting flags. Normalising to a
+// canonical order lets a single lookup dedup the symmetric report (a conflicts b ==
+// b conflicts a).
+type conflictPair struct{ a, b string }
+
 // validateContractGroups runs the structural (build-time) checks on contract
 // groups: a mutex/exactlyone group with fewer than two members is almost always a
 // misspelled group name. It runs once; errors are added to the parser and the
@@ -111,17 +124,16 @@ func (p *Parser) validateContractGroups() error {
 	// Group membership is scoped to the owning command: a mutex/exactlyone group in
 	// `export` is independent of a same-named group in `sync`, so a singleton in one
 	// command is still caught even if another command happens to reuse the label.
-	type groupKey struct{ cmd, label string }
-	counts := map[groupKey]int{}
+	counts := map[contractGroupKey]int{}
 	for _, flagInfo := range p.acceptedFlags.All() {
 		for _, c := range flagInfo.Argument.Contracts {
 			if (c.Kind == ContractMutex || c.Kind == ContractExactlyOne) && len(c.Targets) > 0 {
-				counts[groupKey{flagInfo.CommandPath, c.Targets[0]}]++
+				counts[contractGroupKey{flagInfo.CommandPath, c.Targets[0]}]++
 			}
 		}
 	}
 
-	keys := make([]groupKey, 0, len(counts))
+	keys := make([]contractGroupKey, 0, len(counts))
 	for g := range counts {
 		keys = append(keys, g)
 	}
@@ -171,9 +183,9 @@ func (p *Parser) validateContracts() {
 		key     string
 		present bool
 	}
-	groups := map[string][]member{}
-	groupRequired := map[string]bool{}
-	conflictsReported := map[string]bool{}
+	groups := map[contractGroupKey][]member{}
+	groupRequired := map[contractGroupKey]bool{}
+	conflictsReported := map[conflictPair]bool{}
 
 	for flagKey, flagInfo := range p.acceptedFlags.All() {
 		cmdPath := flagInfo.CommandPath
@@ -187,7 +199,12 @@ func (p *Parser) validateContracts() {
 				if len(c.Targets) == 0 {
 					continue
 				}
-				g := c.Targets[0]
+				// Scope the group to the owning command (same key the build-time
+				// singleton guard uses): without this, two commands invoked in one
+				// line that happen to reuse a group label would merge into a single
+				// group and cross-fire. The flag keys carry the command, so messages
+				// are unaffected.
+				g := contractGroupKey{cmdPath, c.Targets[0]}
 				groups[g] = append(groups[g], member{flagKey, present})
 				if c.Kind == ContractExactlyOne {
 					groupRequired[g] = true
@@ -201,11 +218,16 @@ func (p *Parser) validateContracts() {
 					if !p.HasFlag(otherKey) {
 						continue
 					}
-					// Dedup symmetric reports (a conflicts b == b conflicts a).
-					if conflictsReported[flagKey+"\x00"+otherKey] || conflictsReported[otherKey+"\x00"+flagKey] {
+					// Dedup symmetric reports (a conflicts b == b conflicts a) via a
+					// canonically-ordered pair, so a single lookup covers both directions.
+					pair := conflictPair{flagKey, otherKey}
+					if otherKey < flagKey {
+						pair = conflictPair{otherKey, flagKey}
+					}
+					if conflictsReported[pair] {
 						continue
 					}
-					conflictsReported[flagKey+"\x00"+otherKey] = true
+					conflictsReported[pair] = true
 					p.addError(errs.ErrConflictingFlags.WithArgs(
 						p.formatFlagForError(flagKey), p.formatFlagForError(otherKey)))
 				}
@@ -233,11 +255,16 @@ func (p *Parser) validateContracts() {
 	}
 
 	// mutex: deterministic order, singleton-group guard, then at-most-one.
-	names := make([]string, 0, len(groups))
+	names := make([]contractGroupKey, 0, len(groups))
 	for g := range groups {
 		names = append(names, g)
 	}
-	sort.Strings(names)
+	sort.Slice(names, func(i, j int) bool {
+		if names[i].cmd != names[j].cmd {
+			return names[i].cmd < names[j].cmd
+		}
+		return names[i].label < names[j].label
+	})
 	for _, g := range names {
 		members := groups[g]
 		if len(members) < 2 {

--- a/v2/errs/errors.go
+++ b/v2/errs/errors.go
@@ -20,6 +20,7 @@ var (
 	ErrNonPointerVar                = i18n.NewError(ErrNonPointerVarKey)
 	ErrRequiredFlag                 = i18n.NewError(ErrRequiredFlagKey)
 	ErrRequiredWithDefault          = i18n.NewError(ErrRequiredWithDefaultKey)
+	ErrDefaultInExclusiveGroup      = i18n.NewError(ErrDefaultInExclusiveGroupKey)
 	ErrRequiredPositionalFlag       = i18n.NewError(ErrRequiredPositionalFlagKey)
 	ErrInvalidArgumentType          = i18n.NewError(ErrInvalidArgumentTypeKey)
 	ErrFlagValueNotRetrieved        = i18n.NewError(ErrFlagValueNotRetrievedKey)

--- a/v2/errs/errors.go
+++ b/v2/errs/errors.go
@@ -19,6 +19,7 @@ var (
 	ErrBindNil                      = i18n.NewError(ErrBindNilKey)
 	ErrNonPointerVar                = i18n.NewError(ErrNonPointerVarKey)
 	ErrRequiredFlag                 = i18n.NewError(ErrRequiredFlagKey)
+	ErrRequiredWithDefault          = i18n.NewError(ErrRequiredWithDefaultKey)
 	ErrRequiredPositionalFlag       = i18n.NewError(ErrRequiredPositionalFlagKey)
 	ErrInvalidArgumentType          = i18n.NewError(ErrInvalidArgumentTypeKey)
 	ErrFlagValueNotRetrieved        = i18n.NewError(ErrFlagValueNotRetrievedKey)

--- a/v2/errs/keys.go
+++ b/v2/errs/keys.go
@@ -25,6 +25,7 @@ const (
 	ErrBindNilKey                      = ErrorPrefixKey + ".bind_nil"
 	ErrNonPointerVarKey                = ErrorPrefixKey + ".non_pointer_var"
 	ErrRequiredFlagKey                 = ErrorPrefixKey + ".required_flag"
+	ErrRequiredWithDefaultKey          = ErrorPrefixKey + ".required_with_default"
 	ErrRequiredPositionalFlagKey       = ErrorPrefixKey + ".required_positional_flag"
 	ErrInvalidArgumentTypeKey          = ErrorPrefixKey + ".invalid_argument_type"
 	ErrFlagValueNotRetrievedKey        = ErrorPrefixKey + ".flag_value_not_retrieved"

--- a/v2/errs/keys.go
+++ b/v2/errs/keys.go
@@ -26,6 +26,7 @@ const (
 	ErrNonPointerVarKey                = ErrorPrefixKey + ".non_pointer_var"
 	ErrRequiredFlagKey                 = ErrorPrefixKey + ".required_flag"
 	ErrRequiredWithDefaultKey          = ErrorPrefixKey + ".required_with_default"
+	ErrDefaultInExclusiveGroupKey      = ErrorPrefixKey + ".default_in_exclusive_group"
 	ErrRequiredPositionalFlagKey       = ErrorPrefixKey + ".required_positional_flag"
 	ErrInvalidArgumentTypeKey          = ErrorPrefixKey + ".invalid_argument_type"
 	ErrFlagValueNotRetrievedKey        = ErrorPrefixKey + ".flag_value_not_retrieved"

--- a/v2/goopt.go
+++ b/v2/goopt.go
@@ -1168,6 +1168,19 @@ func (p *Parser) AddFlag(flag string, argument *Argument, commandPath ...string)
 		return errs.ErrRequiredWithDefault.WithArgs(flag)
 	}
 
+	// A default on a mutually-exclusive member (mutex/exactlyone) has no coherent
+	// meaning: a fallback value for an option you select among others can neither
+	// count as a choice (it would permanently win the group) nor be ignored
+	// (it would fire "must set one" despite holding a value). "Pick one with a
+	// default" is a single value flag + isoneof, not a group; reject it here.
+	if argument.DefaultValue != "" {
+		for _, c := range argument.Contracts {
+			if c.Kind == ContractMutex || c.Kind == ContractExactlyOne {
+				return errs.ErrDefaultInExclusiveGroup.WithArgs(flag)
+			}
+		}
+	}
+
 	// Use the helper function to generate the lookup key
 	lookupFlag := buildPathFlag(flag, commandPath...)
 
@@ -1462,7 +1475,15 @@ func (p *Parser) GetShortFlag(flag string, commandPath ...string) (string, error
 	return "", err
 }
 
-// HasFlag returns true when the Flag has been seen on the command line.
+// HasFlag reports whether a value for the flag was explicitly supplied — on the
+// command line, via an environment variable, or via external config
+// (ParseWithDefaults) — as opposed to the flag falling back to its default value.
+//
+// This is provenance, not a value comparison: it returns true even when the
+// supplied value happens to equal the default, and false when the flag is holding
+// its default (or is unset). Reach for it to answer "did the user actually set
+// this?" — e.g. before overriding a defaulted value with your own logic. It does
+// not distinguish which of those sources supplied the value.
 func (p *Parser) HasFlag(flag string, commandPath ...string) bool {
 	// First try canonical lookup
 	mainKey := p.flagOrShortFlag(flag, commandPath...)

--- a/v2/goopt.go
+++ b/v2/goopt.go
@@ -1108,7 +1108,10 @@ func (p *Parser) GetWarnings() []string {
 		}
 
 		for _, depFlag := range dependentFlags {
-			dependKey := p.flagOrShortFlag(depFlag)
+			// Resolve the dependency target within the owning flag's command scope,
+			// so a command-scoped dependent (e.g. beta@cmd) is matched instead of
+			// being looked up by bare name and reported as "not specified".
+			dependKey := p.flagOrShortFlag(depFlag, flagInfo.CommandPath)
 			dependValue, hasKey := p.options[dependKey]
 
 			if !hasKey {
@@ -1156,6 +1159,13 @@ func (p *Parser) AddFlag(flag string, argument *Argument, commandPath ...string)
 
 	if flag == "" {
 		return errs.ErrEmptyFlag
+	}
+
+	// required + default is a contradictory declaration: a default makes the flag
+	// never "missing", so `required` could never fire. Reject it at construction
+	// (Design B) rather than silently picking a winner at parse time.
+	if argument.Required && argument.DefaultValue != "" {
+		return errs.ErrRequiredWithDefault.WithArgs(flag)
 	}
 
 	// Use the helper function to generate the lookup key
@@ -1289,6 +1299,15 @@ func (p *Parser) BindFlag(bindPtr interface{}, flag string, argument *Argument, 
 
 	// Bind the flag to the variable
 	p.bind[lookupFlag] = bindPtr
+
+	// Apply the configured default to the bound variable immediately, so a default
+	// is visible on the bound target whether you bind via a struct or call BindFlag
+	// directly. A value supplied at Parse (cmdline/env/config) overrides it.
+	if argument.DefaultValue != "" {
+		if err := p.setBoundVariable(argument.DefaultValue, lookupFlag); err != nil {
+			p.addError(errs.WrapOnce(err, errs.ErrSettingBoundValue, argument.DefaultValue))
+		}
+	}
 
 	return nil
 }

--- a/v2/goopt.go
+++ b/v2/goopt.go
@@ -906,8 +906,24 @@ func (p *Parser) GetCommands() []string {
 }
 
 // Get returns a combination of a Flag's value as string and true if found. If a flag is not set but has a configured default value
-// the default value is registered and is returned. Returns an empty string and false otherwise
+// the default value is registered and is returned. Returns an empty string and false otherwise.
+//
+// For a Chained (list) flag the returned string is a REPRESENTATION of the list, not
+// guaranteed to match the original input format: the internal occurrence/element
+// marker is rendered as a comma. Use GetList for the structured value.
 func (p *Parser) Get(flag string, commandPath ...string) (string, bool) {
+	value, found := p.getRawValue(flag, commandPath...)
+	if found && strings.ContainsRune(value, chainedInternalSepRune) {
+		value = strings.ReplaceAll(value, chainedInternalSep, ",")
+	}
+	return value, found
+}
+
+// getRawValue resolves a flag's stored value without rendering. Chained values are
+// returned verbatim, still carrying the internal marker — callers that need the
+// structured list (GetList) or the bound-variable split read this and split on
+// chainedSplitFunc; Get renders the marker for display.
+func (p *Parser) getRawValue(flag string, commandPath ...string) (string, bool) {
 	lookup := buildPathFlag(flag, commandPath...)
 	mainKey := p.flagOrShortFlag(lookup, commandPath...)
 	value, found := p.options[mainKey]
@@ -989,20 +1005,22 @@ func (p *Parser) GetFloat(flag string, bitSize int, commandPath ...string) (floa
 	return val, nil
 }
 
-// GetList attempts to split the string value of a Chained Flag to a string slice
-// by default the value is split on '|', ',' or ' ' delimiters
+// GetList returns the elements of a Chained Flag as a string slice. Elements are
+// recovered by splitting the stored value on the configured input delimiter UNION the
+// internal marker (see chainedSplitFunc), so a custom ListDelimiterFunc and repeated
+// occurrences are both honoured — the result matches what a bound []string receives.
 func (p *Parser) GetList(flag string, commandPath ...string) ([]string, error) {
 	arg, err := p.GetArgument(flag, commandPath...)
 	if err == nil {
 		if arg.TypeOf == types.Chained {
-			value, success := p.Get(flag, commandPath...)
+			// Read the RAW stored value (not Get's rendered form) so the marker is
+			// still present to split on.
+			value, success := p.getRawValue(flag, commandPath...)
 			if !success {
 				return []string{}, errs.ErrFlagValueNotRetrieved.WithArgs(flag)
 			}
 
-			listDelimFunc := p.getListDelimiterFunc()
-
-			return strings.FieldsFunc(value, listDelimFunc), nil
+			return strings.FieldsFunc(value, p.chainedSplitFunc()), nil
 		}
 
 		return []string{}, errs.ErrInvalidArgumentType.WithArgs(flag, types.Chained)
@@ -1302,12 +1320,17 @@ func (p *Parser) BindFlag(bindPtr interface{}, flag string, argument *Argument, 
 		}
 	}
 
-	if err := p.AddFlag(flag, argument, commandPath...); err != nil {
-		return err
+	// Infer the option type from the bound variable BEFORE AddFlag. AddFlag defaults
+	// an unset (Empty) type to Single — if inference ran after it, a bound slice would
+	// silently stay a scalar (no list split, no repeated-flag accumulation) and a
+	// bound bool would not become Standalone. Inference maps a slice to Chained, bool
+	// to Standalone, and time.Duration/Time/numerics to Single.
+	if argument.TypeOf == types.Empty {
+		argument.TypeOf = parse.InferFieldType(elem.Type())
 	}
 
-	if argument.TypeOf == types.Empty {
-		argument.TypeOf = parse.InferFieldType(reflect.ValueOf(bindPtr).Elem().Type())
+	if err := p.AddFlag(flag, argument, commandPath...); err != nil {
+		return err
 	}
 
 	// Bind the flag to the variable

--- a/v2/goopt.go
+++ b/v2/goopt.go
@@ -1846,6 +1846,11 @@ func (p *Parser) GetCompletionData() completion.CompletionData {
 		}
 	}
 
+	// Completion must offer a parent command's flags on its subcommands too (the parser
+	// inherits them via parent-walking resolution); applied here so all shell generators
+	// see the same inheritance the parser enforces.
+	applyCommandFlagInheritance(&data)
+
 	return data
 }
 

--- a/v2/goopt_internal.go
+++ b/v2/goopt_internal.go
@@ -529,16 +529,52 @@ func (p *Parser) registerSecureValue(flag, value string) error {
 	return err
 }
 
+// chainedInternalSep is the internal separator for stored Chained (list) values: the
+// ASCII Unit Separator. It is deliberately a control byte that cannot be typed on a
+// command line (or appear in config/env data), so it never collides with a value and
+// is never a user-facing list separator. The user's ListDelimiterFunc remains the
+// sole authority on ELEMENT separation; this marker only delimits the dimensions the
+// user never specifies — repeated-occurrence boundaries and the validated-element
+// rejoin. Stored values are read back by splitting on (user delimiter ∪ this marker),
+// see chainedSplitFunc.
+const chainedInternalSep = "\x1f"
+const chainedInternalSepRune = '\x1f'
+
+// chainedSplitFunc returns the predicate for splitting a STORED chained value back
+// into elements: the configured input delimiter UNION the internal marker. Input
+// parsing uses the user delimiter alone; reading a stored value must additionally
+// break on the marker that joins occurrences and validated elements.
+func (p *Parser) chainedSplitFunc() types.ListDelimiterFunc {
+	input := p.getListDelimiterFunc()
+	return func(r rune) bool { return r == chainedInternalSepRune || input(r) }
+}
+
+// chainedRegisteredDownstream reports whether a Chained flag's options value is
+// written by a step after flagValue: checkMultiple (when it has validators or
+// accepted-values) or the filter block in processValueFlag (when it has pre/post
+// filters). Such flags must NOT also be registered in flagValue, to keep exactly one
+// options write per occurrence.
+func (p *Parser) chainedRegisteredDownstream(argument *Argument) bool {
+	return argument.TypeOf == types.Chained &&
+		(len(argument.Validators) > 0 || len(argument.AcceptedValues) > 0 ||
+			argument.PreFilter != nil || argument.PostFilter != nil)
+}
+
 func (p *Parser) registerFlagValue(flag, value, rawValue string) {
 	parts := splitPathFlag(flag)
 	p.rawArgs[parts[0]] = rawValue
 	p.rawArgs[rawValue] = rawValue
 
-	// For Chained type flags that are repeated, append values
+	// For Chained (list) flags, accumulate repeated occurrences. We store each
+	// occurrence's token verbatim (preserving the user's declared list separator) and
+	// join occurrences with the internal marker — NOT a list separator of our own.
+	// repeatedFlags is now marked per-occurrence for EVERY chained flag (in
+	// processValueFlag), so accumulation no longer depends on the flag being bound to
+	// a variable, and registerFlagValue is called exactly once per occurrence (see the
+	// deferral in flagValue) so a repeat never double-appends.
 	if flagInfo, found := p.acceptedFlags.Get(flag); found && flagInfo.Argument.TypeOf == types.Chained {
 		if existingValue, exists := p.options[flag]; exists && p.repeatedFlags[flag] {
-			// Append with pipe separator (the default for chained values)
-			p.options[flag] = existingValue + "|" + value
+			p.options[flag] = existingValue + chainedInternalSep + value
 			return
 		}
 	}
@@ -782,7 +818,15 @@ func (p *Parser) flagValue(argument *Argument, next string, flag string) (arg st
 			}
 		}
 		arg = next
-		p.registerFlagValue(flag, next, next)
+		// A Chained flag that has validators/accepted-values (split+validated in
+		// checkMultiple) or filters (applied in processValueFlag) is registered by
+		// that downstream step instead. Writing the raw token here too would store it
+		// twice — and, now that repeated accumulation is bind-independent, append it
+		// twice on a repeat. Plain chained flags have no downstream write, so they are
+		// stored here.
+		if !p.chainedRegisteredDownstream(argument) {
+			p.registerFlagValue(flag, next, next)
+		}
 	}
 
 	return arg, err
@@ -1336,9 +1380,9 @@ func (p *Parser) processValueFlag(currentArg string, next string, argument *Argu
 		processed, validationPassed = p.processSingleValue(next, currentArg, argument)
 	} else {
 		haveFilters := argument.PreFilter != nil || argument.PostFilter != nil
+		processed = next
 		if argument.PreFilter != nil {
 			processed = argument.PreFilter(next)
-			p.registerFlagValue(currentArg, processed, next)
 		}
 		if argument.PostFilter != nil {
 			if processed != "" {
@@ -1346,10 +1390,11 @@ func (p *Parser) processValueFlag(currentArg string, next string, argument *Argu
 			} else {
 				processed = argument.PostFilter(next)
 			}
-			p.registerFlagValue(currentArg, processed, next)
 		}
-		if !haveFilters {
-			processed = next
+		if haveFilters {
+			// Register once, after both filters — registering after each would write
+			// (and, for a repeated chained flag, accumulate) twice per occurrence.
+			p.registerFlagValue(currentArg, processed, next)
 		}
 	}
 
@@ -1366,7 +1411,15 @@ func (p *Parser) processValueFlag(currentArg string, next string, argument *Argu
 
 	// Only set bound variable if validation passed
 	if validationPassed {
-		return p.setBoundVariable(processed, currentArg)
+		err := p.setBoundVariable(processed, currentArg)
+		// Mark the occurrence complete for chained flags so a SUBSEQUENT occurrence
+		// accumulates (in both options and any bound slice) rather than replacing —
+		// independent of whether the flag is bound. This is the single per-occurrence
+		// boundary that both registerFlagValue and appendOrSetBoundVariable read.
+		if argument.TypeOf == types.Chained {
+			p.repeatedFlags[currentArg] = true
+		}
+		return err
 	}
 	return nil
 }
@@ -1580,8 +1633,10 @@ func (p *Parser) checkMultiple(next, flag string, argument *Argument) (string, b
 		}
 	}
 
-	// All validations passed for all values
-	value := strings.Join(args, "|")
+	// All validations passed for all values. Join the validated elements with the
+	// internal marker (not a user-facing separator); GetList / ConvertString recover
+	// them by splitting on (user delimiter ∪ marker).
+	value := strings.Join(args, chainedInternalSep)
 	p.registerFlagValue(flag, value, next)
 	return value, true
 }
@@ -1776,9 +1831,12 @@ func (p *Parser) setBoundVariable(value string, currentArg string) error {
 		}
 	}
 
-	// For Chained type with repeated flag support, check if we need to append
+	// For Chained type with repeated flag support, check if we need to append. The
+	// value may carry the internal marker (from checkMultiple's validated rejoin), so
+	// split on (user delimiter ∪ marker) — the same recovery GetList uses — to keep
+	// the bound slice and GetList in lockstep.
 	if flagInfo.Argument.TypeOf == types.Chained {
-		return p.appendOrSetBoundVariable(value, data, currentArg, p.listFunc)
+		return p.appendOrSetBoundVariable(value, data, currentArg, p.chainedSplitFunc())
 	}
 
 	return util.ConvertString(value, data, currentArg, p.listFunc)
@@ -1788,13 +1846,10 @@ func (p *Parser) setBoundVariable(value string, currentArg string) error {
 // or replacing the value for non-slice types. This enables the pattern:
 // -o option1 -o option2 instead of -o "option1,option2"
 func (p *Parser) appendOrSetBoundVariable(value string, data any, currentArg string, delimiterFunc types.ListDelimiterFunc) error {
-	// Check if we've already seen this flag
-	doAppend := true
-	if !p.repeatedFlags[currentArg] {
-		// First occurrence, mark it as seen and set normally
-		p.repeatedFlags[currentArg] = true
-		doAppend = false
-	}
+	// Append when this flag was already completed in a PRIOR occurrence; otherwise
+	// set. The per-occurrence mark is owned by processValueFlag (bind-independent), so
+	// the first occurrence reads false (set) and later ones read true (append).
+	doAppend := p.repeatedFlags[currentArg]
 
 	return util.ConvertString(value, data, currentArg, delimiterFunc, doAppend)
 }

--- a/v2/goopt_internal.go
+++ b/v2/goopt_internal.go
@@ -55,20 +55,14 @@ func (p *Parser) parseFlag(state parse.State, currentCommandPath string) bool {
 		}
 	}
 
-	// If not found, try translation lookup
+	// If not found, try translation lookup. Resolve the canonical name through the
+	// same parent-walking resolver used for the canonical name above, so a
+	// translated name inherits across command scope exactly as its canonical does
+	// (e.g. --<translated> on a parent-command flag works under a subcommand).
 	if !found {
 		if canonical, ok := p.translationRegistry.GetCanonicalFlagName(flagName, p.GetLanguage()); ok {
-			// The canonical name might already include command context (e.g., "flag@command")
-			// Try it as-is first
-			flag = canonical
+			flag = p.flagOrShortFlag(canonical, currentCommandPath)
 			flagInfo, found = p.acceptedFlags.Get(flag)
-
-			// If not found and we have a command path, try building the full path
-			if !found && currentCommandPath != "" {
-				commandParts := strings.Split(currentCommandPath, " ")
-				flag = buildPathFlag(canonical, commandParts...)
-				flagInfo, found = p.acceptedFlags.Get(flag)
-			}
 		}
 	}
 
@@ -2402,13 +2396,6 @@ func (p *Parser) processPathTag(pathTag string, fieldValue reflect.Value, fullFl
 		if err != nil {
 			return err
 		}
-		if arg.DefaultValue != "" {
-			err = p.setBoundVariable(arg.DefaultValue, buildPathFlag(fullFlagName, cmdPath))
-			if err != nil {
-				// Default value binding errors are not critical - collect them
-				p.addError(errs.WrapOnce(err, errs.ErrSettingBoundValue, arg.DefaultValue))
-			}
-		}
 	}
 
 	return nil
@@ -2436,17 +2423,6 @@ func (p *Parser) bindArgument(commandPath string, fieldValue reflect.Value, full
 	}
 	if err != nil {
 		return err
-	}
-	if arg.DefaultValue != "" {
-		if commandPath != "" {
-			err = p.setBoundVariable(arg.DefaultValue, buildPathFlag(fullFlagName, commandPath))
-		} else {
-			err = p.setBoundVariable(arg.DefaultValue, fullFlagName)
-		}
-		if err != nil {
-			// Default value binding errors are not critical - collect them
-			p.addError(errs.WrapOnce(err, errs.ErrSettingBoundValue, arg.DefaultValue))
-		}
 	}
 
 	return nil
@@ -2833,6 +2809,16 @@ func getFlagPath(flag string) string {
 func (p *Parser) formatFlagForError(flag string) string {
 	parts := splitPathFlag(flag)
 	if len(parts) == 2 && parts[1] != "" {
+		// Omit the "(in command 'x')" qualifier when that command was actually
+		// invoked: the user already knows which command they ran, so repeating it
+		// (e.g. once per flag in a contract error) is noise. The qualifier is kept
+		// only for a flag of a command that was not invoked, where it genuinely
+		// disambiguates.
+		for _, cmd := range p.GetCommands() {
+			if cmd == parts[1] || strings.HasPrefix(cmd, parts[1]+" ") {
+				return p.quoteForError(parts[0])
+			}
+		}
 		// Format as: 'flag' (in command 'command')
 		inCommandMsg := p.layeredProvider.GetMessage(messages.MsgInCommandKey)
 		return p.quoteForError(parts[0]) + " (" + inCommandMsg + " " + p.quoteForError(parts[1]) + ")"

--- a/v2/goopt_internal.go
+++ b/v2/goopt_internal.go
@@ -2911,7 +2911,13 @@ func addFlagToCompletionData(data *completion.CompletionData, cmd, flagName stri
 		data.CommandFlags[cmd] = append(data.CommandFlags[cmd], pair)
 	}
 
-	// Handle flag values
+	// Handle flag values. NOTE: AcceptedValues is deprecated (superseded by
+	// validators); this keeps value-completion correct while it sunsets — do not grow
+	// it with command-aware keys. Key by the BARE flag name(s) — exactly what every
+	// generator reads (data.FlagValues[flag.Long]). The old code stored only when a
+	// short existed and prefixed command-scoped keys with "cmd@", a key no generator
+	// ever looks up — so value completion was dead for long-only and command-scoped
+	// flags.
 	if len(flagInfo.Argument.AcceptedValues) > 0 {
 		values := make([]completion.CompletionValue, len(flagInfo.Argument.AcceptedValues))
 		for i, v := range flagInfo.Argument.AcceptedValues {
@@ -2921,18 +2927,44 @@ func addFlagToCompletionData(data *completion.CompletionData, cmd, flagName stri
 			}
 		}
 
-		// Add values for both forms if short exists
-		if flagInfo.Argument.Short != "" {
-			shortKey := pair.Short
-			longKey := pair.Long
-			if cmd != "" {
-				shortKey = cmd + "@" + shortKey
-				longKey = cmd + "@" + longKey
-			}
-			data.FlagValues[shortKey] = values
-			data.FlagValues[longKey] = values
+		data.FlagValues[pair.Long] = values
+		if pair.Short != "" {
+			data.FlagValues[pair.Short] = values
 		}
 	}
+}
+
+// applyCommandFlagInheritance rewrites data.CommandFlags so each command lists its OWN
+// flags plus those inherited from every ancestor command — mirroring the parser's
+// parent-walking flag resolution, so completion offers exactly what the parser accepts
+// (without this, a parent command's flags are silently absent from subcommand
+// completion even though the parser accepts them there). The nearest owner wins on a
+// name collision, matching the parser's nearest-ancestor override. Ancestors are the
+// space-joined path prefixes the parser itself walks.
+func applyCommandFlagInheritance(data *completion.CompletionData) {
+	if len(data.CommandFlags) == 0 {
+		return
+	}
+	ownFlags := data.CommandFlags
+	merged := make(map[string][]completion.FlagPair, len(ownFlags))
+	for _, path := range data.Commands {
+		seen := make(map[string]bool)
+		var flags []completion.FlagPair
+		tokens := strings.Split(path, " ")
+		for i := len(tokens); i >= 1; i-- { // own path first, then ancestors
+			for _, fp := range ownFlags[strings.Join(tokens[:i], " ")] {
+				if seen[fp.Long] {
+					continue // a nearer command already defines this flag
+				}
+				seen[fp.Long] = true
+				flags = append(flags, fp)
+			}
+		}
+		if len(flags) > 0 {
+			merged[path] = flags
+		}
+	}
+	data.CommandFlags = merged
 }
 
 func isFieldCommand(field reflect.StructField) bool {

--- a/v2/goopt_test.go
+++ b/v2/goopt_test.go
@@ -15566,10 +15566,23 @@ func TestParser_FormatFlagForError(t *testing.T) {
 		assert.NotEmpty(t, errors)
 		errorMsg := errors[0].Error()
 
-		// The error should contain the formatted flag name
+		// The error shows the formatted flag name. Because "deploy" was actually
+		// invoked, the "(in command 'deploy')" qualifier is suppressed as redundant.
 		assert.Contains(t, errorMsg, "'email'")
-		assert.Contains(t, errorMsg, "in command")
-		assert.Contains(t, errorMsg, "'deploy'")
+		assert.NotContains(t, errorMsg, "in command")
+		assert.NotContains(t, errorMsg, "'deploy'")
+	})
+
+	t.Run("qualifier suppressed for invoked command, kept otherwise", func(t *testing.T) {
+		parser := NewParser()
+		require.NoError(t, parser.AddCommand(&Command{Name: "deploy"}))
+		require.NoError(t, parser.AddCommand(&Command{Name: "build"}))
+		parser.Parse([]string{"prog", "deploy"})
+
+		// Flag of the invoked command -> qualifier omitted (the user knows they ran deploy).
+		assert.Equal(t, "'token'", parser.formatFlagForError("token@deploy"))
+		// Flag of a command that was NOT invoked -> qualifier kept for disambiguation.
+		assert.Equal(t, "'config' (in command 'build')", parser.formatFlagForError("config@build"))
 	})
 }
 

--- a/v2/goopt_test.go
+++ b/v2/goopt_test.go
@@ -12897,14 +12897,16 @@ func TestParser_BindFlagWithSlices(t *testing.T) {
 		var value bool
 
 		err := parser.BindFlag(&value, "flag", &Argument{
-			TypeOf: types.Empty, // Should infer as Standalone for bool
+			TypeOf: types.Empty, // bool with an unset type must infer as Standalone
 		})
 		require.NoError(t, err)
 
-		// Verify type was inferred (bool becomes Single when TypeOf is Empty)
+		// A bound bool infers Standalone (presence-flag): inference now runs BEFORE
+		// AddFlag's Empty->Single default, which previously masked it (the old test
+		// asserted the masked Single value).
 		arg, err := parser.GetArgument("flag")
 		assert.NoError(t, err)
-		assert.Equal(t, types.Single, arg.TypeOf)
+		assert.Equal(t, types.Standalone, arg.TypeOf)
 	})
 }
 

--- a/v2/i18n/all_locales/ar.json
+++ b/v2/i18n/all_locales/ar.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.required_with_default": "لا يمكن أن تكون العلامة %[1]q مطلوبة ولها قيمة افتراضية في آن واحد (القيمة الافتراضية تجعلها لا تغيب أبدًا)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",
   "goopt.error.bind_invalid_value_field": "لا يمكن الربط بحقل قيمة غير صالح",

--- a/v2/i18n/all_locales/ar.json
+++ b/v2/i18n/all_locales/ar.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.default_in_exclusive_group": "لا يمكن أن تحتوي العلامة %[1]q على قيمة افتراضية لأنها جزء من مجموعة حصرية متبادلة (mutex/exactlyone)",
   "goopt.error.required_with_default": "لا يمكن أن تكون العلامة %[1]q مطلوبة ولها قيمة افتراضية في آن واحد (القيمة الافتراضية تجعلها لا تغيب أبدًا)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",

--- a/v2/i18n/all_locales/de.json
+++ b/v2/i18n/all_locales/de.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.default_in_exclusive_group": "Flag %[1]q kann keinen Standardwert haben, da es Teil einer sich gegenseitig ausschließenden Gruppe ist (mutex/exactlyone)",
   "goopt.error.required_with_default": "Flag %[1]q kann nicht gleichzeitig erforderlich sein und einen Standardwert haben (ein Standardwert sorgt dafür, dass es nie fehlt)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",

--- a/v2/i18n/all_locales/de.json
+++ b/v2/i18n/all_locales/de.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.required_with_default": "Flag %[1]q kann nicht gleichzeitig erforderlich sein und einen Standardwert haben (ein Standardwert sorgt dafür, dass es nie fehlt)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",
   "goopt.error.bind_invalid_value_field": "Kann nicht an ungültiges Wertfeld binden",

--- a/v2/i18n/all_locales/en.json
+++ b/v2/i18n/all_locales/en.json
@@ -1,4 +1,5 @@
 {
+    "goopt.error.required_with_default": "flag %[1]q cannot be both required and have a default value (a default makes it never missing)",
     "goopt.msg.quote_open": "'",
     "goopt.msg.quote_close": "'",
     "goopt.error.unsupported_type": "unsupported type conversion",

--- a/v2/i18n/all_locales/en.json
+++ b/v2/i18n/all_locales/en.json
@@ -1,4 +1,5 @@
 {
+    "goopt.error.default_in_exclusive_group": "flag %[1]q cannot have a default value because it is part of a mutually-exclusive group (mutex/exactlyone)",
     "goopt.error.required_with_default": "flag %[1]q cannot be both required and have a default value (a default makes it never missing)",
     "goopt.msg.quote_open": "'",
     "goopt.msg.quote_close": "'",

--- a/v2/i18n/all_locales/es.json
+++ b/v2/i18n/all_locales/es.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.default_in_exclusive_group": "la bandera %[1]q no puede tener un valor predeterminado porque forma parte de un grupo mutuamente excluyente (mutex/exactlyone)",
   "goopt.error.required_with_default": "la bandera %[1]q no puede ser obligatoria y tener un valor predeterminado a la vez (un valor predeterminado hace que nunca falte)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",

--- a/v2/i18n/all_locales/es.json
+++ b/v2/i18n/all_locales/es.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.required_with_default": "la bandera %[1]q no puede ser obligatoria y tener un valor predeterminado a la vez (un valor predeterminado hace que nunca falte)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",
   "goopt.error.bind_invalid_value_field": "no se puede vincular a un campo de valor inválido",

--- a/v2/i18n/all_locales/fr.json
+++ b/v2/i18n/all_locales/fr.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.default_in_exclusive_group": "l'option %[1]q ne peut pas avoir de valeur par défaut car elle fait partie d'un groupe mutuellement exclusif (mutex/exactlyone)",
   "goopt.error.required_with_default": "l'option %[1]q ne peut pas être à la fois requise et avoir une valeur par défaut (une valeur par défaut fait qu'elle n'est jamais manquante)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",

--- a/v2/i18n/all_locales/fr.json
+++ b/v2/i18n/all_locales/fr.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.required_with_default": "l'option %[1]q ne peut pas être à la fois requise et avoir une valeur par défaut (une valeur par défaut fait qu'elle n'est jamais manquante)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",
   "goopt.error.bind_invalid_value_field": "impossible de lier à un champ de valeur invalide",

--- a/v2/i18n/all_locales/he.json
+++ b/v2/i18n/all_locales/he.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.default_in_exclusive_group": "דגל %[1]q לא יכול להיות בעל ערך ברירת מחדל מכיוון שהוא חלק מקבוצה הדדית בלעדית (mutex/exactlyone)",
   "goopt.error.required_with_default": "דגל %[1]q לא יכול להיות גם נדרש וגם בעל ערך ברירת מחדל (ערך ברירת מחדל גורם לכך שלעולם לא יחסר)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",

--- a/v2/i18n/all_locales/he.json
+++ b/v2/i18n/all_locales/he.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.required_with_default": "דגל %[1]q לא יכול להיות גם נדרש וגם בעל ערך ברירת מחדל (ערך ברירת מחדל גורם לכך שלעולם לא יחסר)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",
   "goopt.error.bind_invalid_value_field": "לא ניתן לקשור לשדה ערך לא חוקי",

--- a/v2/i18n/all_locales/hi.json
+++ b/v2/i18n/all_locales/hi.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.required_with_default": "फ़्लैग %[1]q एक साथ आवश्यक नहीं हो सकता और उसका डिफ़ॉल्ट मान भी हो (डिफ़ॉल्ट मान इसे कभी अनुपस्थित नहीं होने देता)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",
   "goopt.error.bind_invalid_value_field": "अमान्य मान फ़ील्ड से बाइंड नहीं किया जा सकता",

--- a/v2/i18n/all_locales/hi.json
+++ b/v2/i18n/all_locales/hi.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.default_in_exclusive_group": "फ़्लैग %[1]q का डिफ़ॉल्ट मान नहीं हो सकता क्योंकि यह एक पारस्परिक रूप से अनन्य समूह (mutex/exactlyone) का हिस्सा है",
   "goopt.error.required_with_default": "फ़्लैग %[1]q एक साथ आवश्यक नहीं हो सकता और उसका डिफ़ॉल्ट मान भी हो (डिफ़ॉल्ट मान इसे कभी अनुपस्थित नहीं होने देता)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",

--- a/v2/i18n/all_locales/ja.json
+++ b/v2/i18n/all_locales/ja.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.default_in_exclusive_group": "フラグ %[1]q は相互排他グループ（mutex/exactlyone）の一部であるため、デフォルト値を持つことはできません",
   "goopt.error.required_with_default": "フラグ %[1]q は必須でありながらデフォルト値を持つことはできません（デフォルト値があると決して欠落しません）",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",

--- a/v2/i18n/all_locales/ja.json
+++ b/v2/i18n/all_locales/ja.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.required_with_default": "フラグ %[1]q は必須でありながらデフォルト値を持つことはできません（デフォルト値があると決して欠落しません）",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",
   "goopt.error.bind_invalid_value_field": "無効な値フィールドにバインドできません",

--- a/v2/i18n/all_locales/pt.json
+++ b/v2/i18n/all_locales/pt.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.required_with_default": "a flag %[1]q não pode ser obrigatória e ter um valor padrão ao mesmo tempo (um valor padrão faz com que nunca esteja ausente)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",
   "goopt.error.bind_invalid_value_field": "não é possível vincular a campo de valor inválido",

--- a/v2/i18n/all_locales/pt.json
+++ b/v2/i18n/all_locales/pt.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.default_in_exclusive_group": "a flag %[1]q não pode ter um valor padrão porque faz parte de um grupo mutuamente exclusivo (mutex/exactlyone)",
   "goopt.error.required_with_default": "a flag %[1]q não pode ser obrigatória e ter um valor padrão ao mesmo tempo (um valor padrão faz com que nunca esteja ausente)",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",

--- a/v2/i18n/all_locales/zh.json
+++ b/v2/i18n/all_locales/zh.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.default_in_exclusive_group": "标志 %[1]q 属于互斥组（mutex/exactlyone），因此不能有默认值",
   "goopt.error.required_with_default": "标志 %[1]q 不能既是必需的又具有默认值（默认值使其永远不会缺失）",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",

--- a/v2/i18n/all_locales/zh.json
+++ b/v2/i18n/all_locales/zh.json
@@ -1,4 +1,5 @@
 {
+  "goopt.error.required_with_default": "标志 %[1]q 不能既是必需的又具有默认值（默认值使其永远不会缺失）",
   "goopt.msg.quote_open": "'",
   "goopt.msg.quote_close": "'",
   "goopt.error.bind_invalid_value_field": "无法绑定到无效的值字段",

--- a/v2/i18n/locales/ar/ar_gen.go
+++ b/v2/i18n/locales/ar/ar_gen.go
@@ -105,6 +105,7 @@ const SystemTranslations = `{
         "goopt.error.required_flag": "العلامة المطلوبة مفقودة: %[1]s",
         "goopt.error.required_positional_flag": "الوسيطة الموضعية المطلوبة %[1]s في الفهرس %[2]d مفقودة",
         "goopt.error.required_when": "%[1]s مطلوب عند استخدام %[2]s",
+        "goopt.error.required_with_default": "لا يمكن أن تكون العلامة %[1]q مطلوبة ولها قيمة افتراضية في آن واحد (القيمة الافتراضية تجعلها لا تغيب أبدًا)",
         "goopt.error.secure_flag_expects_value": "تتوقع العلامة الآمنة %[1]s قيمة ولكننا فشلنا في الحصول عليها",
         "goopt.error.setting_bound_variable_value": "خطأ في تعيين قيمة المتغير المرتبط للعلامة %[1]s",
         "goopt.error.short_flag_conflict": "تتعارض العلامة القصيرة '%[1]s' في العلامة العامة %[2]s الموجودة بالفعل كـ %[3]v",

--- a/v2/i18n/locales/ar/ar_gen.go
+++ b/v2/i18n/locales/ar/ar_gen.go
@@ -20,6 +20,7 @@ const SystemTranslations = `{
         "goopt.error.configuring_parser": "خطأ في تكوين المحلل",
         "goopt.error.conflicting_flags": "لا يمكن استخدام %[1]s و %[2]s معًا",
         "goopt.error.contract_args": "العقد %[1]q يحتوي على عدد خاطئ من الوسائط",
+        "goopt.error.default_in_exclusive_group": "لا يمكن أن تحتوي العلامة %[1]q على قيمة افتراضية لأنها جزء من مجموعة حصرية متبادلة (mutex/exactlyone)",
         "goopt.error.dependency_not_specified": "العلامة %[1]s تعتمد على %[2]s التي لم يتم تحديدها.",
         "goopt.error.dependency_on_empty_flag": "لا يمكن تحديد تبعية على علامة فارغة",
         "goopt.error.dependency_value_not_specified": "العلامة %[1]s تعتمد على %[2]s بالقيمة %[3]s التي لم يتم تحديدها. (تم الحصول على %[4]q)",

--- a/v2/i18n/locales/de/de_gen.go
+++ b/v2/i18n/locales/de/de_gen.go
@@ -105,6 +105,7 @@ const SystemTranslations = `{
         "goopt.error.required_flag": "Erforderliches Flag fehlt: %[1]s",
         "goopt.error.required_positional_flag": "Fehlender erforderlicher Positional-Argument %[1]s an Index %[2]d",
         "goopt.error.required_when": "%[1]s ist erforderlich, wenn %[2]s verwendet wird",
+        "goopt.error.required_with_default": "Flag %[1]q kann nicht gleichzeitig erforderlich sein und einen Standardwert haben (ein Standardwert sorgt dafür, dass es nie fehlt)",
         "goopt.error.secure_flag_expects_value": "Flag %[1]s erwartet einen Wert, konnte aber nicht erhalten",
         "goopt.error.setting_bound_variable_value": "Fehler beim Setzen des gebundenen Variablenwerts für Flag %[1]s",
         "goopt.error.short_flag_conflict": "Kurzflag '%[1]s' auf globalem Flag %[2]s existiert bereits als %[3]v",

--- a/v2/i18n/locales/de/de_gen.go
+++ b/v2/i18n/locales/de/de_gen.go
@@ -20,6 +20,7 @@ const SystemTranslations = `{
         "goopt.error.configuring_parser": "Fehler beim Konfigurieren des Parsers",
         "goopt.error.conflicting_flags": "%[1]s und %[2]s können nicht zusammen verwendet werden",
         "goopt.error.contract_args": "Vertrag %[1]q hat die falsche Anzahl von Argumenten",
+        "goopt.error.default_in_exclusive_group": "Flag %[1]q kann keinen Standardwert haben, da es Teil einer sich gegenseitig ausschließenden Gruppe ist (mutex/exactlyone)",
         "goopt.error.dependency_not_specified": "Flag %[1]s hängt von %[2]s ab, das nicht angegeben wurde.",
         "goopt.error.dependency_on_empty_flag": "Kann Abhängigkeit von leerem Flag nicht spezifizieren",
         "goopt.error.dependency_value_not_specified": "Flag %[1]s hängt von %[2]s mit Wert %[3]s ab, der nicht angegeben wurde. (Erhalten: '%[4]s')",

--- a/v2/i18n/locales/en/en_gen.go
+++ b/v2/i18n/locales/en/en_gen.go
@@ -105,6 +105,7 @@ const SystemTranslations = `{
         "goopt.error.required_flag": "required flag missing: %[1]s",
         "goopt.error.required_positional_flag": "missing required positional argument %[1]s at index %[2]d",
         "goopt.error.required_when": "%[1]s is required when %[2]s is used",
+        "goopt.error.required_with_default": "flag %[1]q cannot be both required and have a default value (a default makes it never missing)",
         "goopt.error.secure_flag_expects_value": "secure flag %[1]s expects a value but we failed to obtain one",
         "goopt.error.setting_bound_variable_value": "error setting bound variable value for flag %[1]s",
         "goopt.error.short_flag_conflict": "short flag '%[1]s' on global flag %[2]s already exists as %[3]v",

--- a/v2/i18n/locales/en/en_gen.go
+++ b/v2/i18n/locales/en/en_gen.go
@@ -20,6 +20,7 @@ const SystemTranslations = `{
         "goopt.error.configuring_parser": "error configuring parser",
         "goopt.error.conflicting_flags": "%[1]s and %[2]s cannot be used together",
         "goopt.error.contract_args": "contract %[1]q has the wrong number of arguments",
+        "goopt.error.default_in_exclusive_group": "flag %[1]q cannot have a default value because it is part of a mutually-exclusive group (mutex/exactlyone)",
         "goopt.error.dependency_not_specified": "Flag %[1]s depends on %[2]s which was not specified.",
         "goopt.error.dependency_on_empty_flag": "can't specify dependency on empty flag",
         "goopt.error.dependency_value_not_specified": "Flag %[1]s depends on %[2]s with value %[3]s which was not specified. (got %[4]q)",

--- a/v2/i18n/locales/es/es_gen.go
+++ b/v2/i18n/locales/es/es_gen.go
@@ -20,6 +20,7 @@ const SystemTranslations = `{
         "goopt.error.configuring_parser": "error al configurar el analizador",
         "goopt.error.conflicting_flags": "%[1]s y %[2]s no se pueden usar juntos",
         "goopt.error.contract_args": "el contrato %[1]q tiene un número incorrecto de argumentos",
+        "goopt.error.default_in_exclusive_group": "la bandera %[1]q no puede tener un valor predeterminado porque forma parte de un grupo mutuamente excluyente (mutex/exactlyone)",
         "goopt.error.dependency_not_specified": "La bandera %[1]s depende de %[2]s que no fue especificada.",
         "goopt.error.dependency_on_empty_flag": "no se puede especificar dependencia en una bandera vacía",
         "goopt.error.dependency_value_not_specified": "La bandera %[1]s depende de %[2]s con valor %[3]s que no fue especificado. (se obtuvo %[4]q)",

--- a/v2/i18n/locales/es/es_gen.go
+++ b/v2/i18n/locales/es/es_gen.go
@@ -105,6 +105,7 @@ const SystemTranslations = `{
         "goopt.error.required_flag": "falta la bandera requerida: %[1]s",
         "goopt.error.required_positional_flag": "falta el argumento posicional requerido %[1]s en el índice %[2]d",
         "goopt.error.required_when": "%[1]s es obligatorio cuando se usa %[2]s",
+        "goopt.error.required_with_default": "la bandera %[1]q no puede ser obligatoria y tener un valor predeterminado a la vez (un valor predeterminado hace que nunca falte)",
         "goopt.error.secure_flag_expects_value": "la bandera segura %[1]s espera un valor pero no se pudo obtener uno",
         "goopt.error.setting_bound_variable_value": "error al establecer el valor de la variable vinculada para la bandera %[1]s",
         "goopt.error.short_flag_conflict": "la bandera corta '%[1]s' en la bandera global %[2]s ya existe como %[3]v",

--- a/v2/i18n/locales/fr/fr_gen.go
+++ b/v2/i18n/locales/fr/fr_gen.go
@@ -20,6 +20,7 @@ const SystemTranslations = `{
         "goopt.error.configuring_parser": "erreur de configuration de l'analyseur",
         "goopt.error.conflicting_flags": "%[1]s et %[2]s ne peuvent pas être utilisés ensemble",
         "goopt.error.contract_args": "le contrat %[1]q a un nombre incorrect d'arguments",
+        "goopt.error.default_in_exclusive_group": "l'option %[1]q ne peut pas avoir de valeur par défaut car elle fait partie d'un groupe mutuellement exclusif (mutex/exactlyone)",
         "goopt.error.dependency_not_specified": "L'option %[1]s dépend de %[2]s qui n'a pas été spécifiée",
         "goopt.error.dependency_on_empty_flag": "impossible de spécifier une dépendance sur une option vide",
         "goopt.error.dependency_value_not_specified": "L'option %[1]s dépend de %[2]s avec la valeur %[3]s qui n'a pas été spécifiée (reçu %[4]q)",

--- a/v2/i18n/locales/fr/fr_gen.go
+++ b/v2/i18n/locales/fr/fr_gen.go
@@ -105,6 +105,7 @@ const SystemTranslations = `{
         "goopt.error.required_flag": "option requise manquante : %[1]s",
         "goopt.error.required_positional_flag": "argument positionnel requis %[1]s manquant à l'index %[2]d",
         "goopt.error.required_when": "%[1]s est requis lorsque %[2]s est utilisé",
+        "goopt.error.required_with_default": "l'option %[1]q ne peut pas être à la fois requise et avoir une valeur par défaut (une valeur par défaut fait qu'elle n'est jamais manquante)",
         "goopt.error.secure_flag_expects_value": "l'option sécurisée %[1]s attend une valeur mais nous n'avons pas pu l'obtenir",
         "goopt.error.setting_bound_variable_value": "erreur lors de la définition de la valeur de la variable liée pour l'option %[1]s",
         "goopt.error.short_flag_conflict": "l'option courte '%[1]s' sur l'option globale %[2]s existe déjà comme %[3]v",

--- a/v2/i18n/locales/he/he_gen.go
+++ b/v2/i18n/locales/he/he_gen.go
@@ -20,6 +20,7 @@ const SystemTranslations = `{
         "goopt.error.configuring_parser": "שגיאה בהגדרת המנתח",
         "goopt.error.conflicting_flags": "לא ניתן להשתמש ב-%[1]s וב-%[2]s יחד",
         "goopt.error.contract_args": "לחוזה %[1]q יש מספר שגוי של ארגומנטים",
+        "goopt.error.default_in_exclusive_group": "דגל %[1]q לא יכול להיות בעל ערך ברירת מחדל מכיוון שהוא חלק מקבוצה הדדית בלעדית (mutex/exactlyone)",
         "goopt.error.dependency_not_specified": "דגל %[1]s תלוי ב-%[2]s שלא צוין.",
         "goopt.error.dependency_on_empty_flag": "לא ניתן לציין תלות בדגל ריק",
         "goopt.error.dependency_value_not_specified": "דגל %[1]s תלוי ב-%[2]s עם ערך %[3]s שלא צוין. (התקבל %[4]q)",

--- a/v2/i18n/locales/he/he_gen.go
+++ b/v2/i18n/locales/he/he_gen.go
@@ -105,6 +105,7 @@ const SystemTranslations = `{
         "goopt.error.required_flag": "דגל נדרש חסר: %[1]s",
         "goopt.error.required_positional_flag": "חסר ארגומנט מיקומי נדרש %[1]s באינדקס %[2]d",
         "goopt.error.required_when": "%[1]s נדרש כאשר נעשה שימוש ב-%[2]s",
+        "goopt.error.required_with_default": "דגל %[1]q לא יכול להיות גם נדרש וגם בעל ערך ברירת מחדל (ערך ברירת מחדל גורם לכך שלעולם לא יחסר)",
         "goopt.error.secure_flag_expects_value": "דגל מאובטח %[1]s מצפה לערך אך לא הצלחנו להשיג אותו",
         "goopt.error.setting_bound_variable_value": "שגיאה בהגדרת ערך משתנה קשור עבור דגל %[1]s",
         "goopt.error.short_flag_conflict": "דגל קצר '%[1]s' בדגל גלובלי %[2]s כבר קיים כ-%[3]v",

--- a/v2/i18n/locales/hi/hi_gen.go
+++ b/v2/i18n/locales/hi/hi_gen.go
@@ -20,6 +20,7 @@ const SystemTranslations = `{
         "goopt.error.configuring_parser": "पार्सर को कॉन्फ़िगर करने में त्रुटि",
         "goopt.error.conflicting_flags": "%[1]s और %[2]s का एक साथ उपयोग नहीं किया जा सकता",
         "goopt.error.contract_args": "अनुबंध %[1]q में तर्कों की गलत संख्या है",
+        "goopt.error.default_in_exclusive_group": "फ़्लैग %[1]q का डिफ़ॉल्ट मान नहीं हो सकता क्योंकि यह एक पारस्परिक रूप से अनन्य समूह (mutex/exactlyone) का हिस्सा है",
         "goopt.error.dependency_not_specified": "फ़्लैग %[1]s, %[2]s पर निर्भर करता है जिसे निर्दिष्ट नहीं किया गया था।",
         "goopt.error.dependency_on_empty_flag": "खाली फ़्लैग पर निर्भरता निर्दिष्ट नहीं की जा सकती",
         "goopt.error.dependency_value_not_specified": "फ़्लैग %[1]s, मान %[3]s के साथ %[2]s पर निर्भर करता है जिसे निर्दिष्ट नहीं किया गया था। (%[4]q मिला)",

--- a/v2/i18n/locales/hi/hi_gen.go
+++ b/v2/i18n/locales/hi/hi_gen.go
@@ -105,6 +105,7 @@ const SystemTranslations = `{
         "goopt.error.required_flag": "आवश्यक फ्लैग गायब है: %[1]s",
         "goopt.error.required_positional_flag": "सूचकांक %[2]d पर आवश्यक स्थितीय तर्क %[1]s गायब है",
         "goopt.error.required_when": "जब %[2]s का उपयोग किया जाता है तो %[1]s आवश्यक है",
+        "goopt.error.required_with_default": "फ़्लैग %[1]q एक साथ आवश्यक नहीं हो सकता और उसका डिफ़ॉल्ट मान भी हो (डिफ़ॉल्ट मान इसे कभी अनुपस्थित नहीं होने देता)",
         "goopt.error.secure_flag_expects_value": "सुरक्षित फ़्लैग %[1]s को एक मान की उम्मीद है लेकिन हम एक प्राप्त करने में विफल रहे",
         "goopt.error.setting_bound_variable_value": "फ़्लैग %[1]s के लिए बाउंड चर मान सेट करने में त्रुटि",
         "goopt.error.short_flag_conflict": "वैश्विक फ़्लैग %[2]s पर संक्षिप्त फ़्लैग '%[1]s' पहले से ही %[3]v के रूप में मौजूद है",

--- a/v2/i18n/locales/ja/ja_gen.go
+++ b/v2/i18n/locales/ja/ja_gen.go
@@ -20,6 +20,7 @@ const SystemTranslations = `{
         "goopt.error.configuring_parser": "パーサーの設定中にエラーが発生しました",
         "goopt.error.conflicting_flags": "%[1]s と %[2]s は同時に使用できません",
         "goopt.error.contract_args": "契約 %[1]q の引数の数が正しくありません",
+        "goopt.error.default_in_exclusive_group": "フラグ %[1]q は相互排他グループ（mutex/exactlyone）の一部であるため、デフォルト値を持つことはできません",
         "goopt.error.dependency_not_specified": "フラグ %[1]s は指定されていない %[2]s に依存しています。",
         "goopt.error.dependency_on_empty_flag": "空のフラグへの依存関係を指定できません",
         "goopt.error.dependency_value_not_specified": "フラグ %[1]s は値 %[3]s を持つ %[2]s に依存していますが、指定されていません（%[4]q を取得）",

--- a/v2/i18n/locales/ja/ja_gen.go
+++ b/v2/i18n/locales/ja/ja_gen.go
@@ -105,6 +105,7 @@ const SystemTranslations = `{
         "goopt.error.required_flag": "必須フラグがありません: %[1]s",
         "goopt.error.required_positional_flag": "インデックス %[2]d の必須位置引数 %[1]s がありません",
         "goopt.error.required_when": "%[2]s を使用する場合は %[1]s が必要です",
+        "goopt.error.required_with_default": "フラグ %[1]q は必須でありながらデフォルト値を持つことはできません（デフォルト値があると決して欠落しません）",
         "goopt.error.secure_flag_expects_value": "セキュアフラグ %[1]s は値を必要としますが、取得に失敗しました",
         "goopt.error.setting_bound_variable_value": "フラグ %[1]s のバインドされた変数値の設定中にエラーが発生しました",
         "goopt.error.short_flag_conflict": "グローバルフラグ %[2]s の短縮フラグ '%[1]s' は既に %[3]v として存在します",

--- a/v2/i18n/locales/pt/pt_gen.go
+++ b/v2/i18n/locales/pt/pt_gen.go
@@ -20,6 +20,7 @@ const SystemTranslations = `{
         "goopt.error.configuring_parser": "erro ao configurar o analisador",
         "goopt.error.conflicting_flags": "%[1]s e %[2]s não podem ser usados juntos",
         "goopt.error.contract_args": "o contrato %[1]q tem um número incorreto de argumentos",
+        "goopt.error.default_in_exclusive_group": "a flag %[1]q não pode ter um valor padrão porque faz parte de um grupo mutuamente exclusivo (mutex/exactlyone)",
         "goopt.error.dependency_not_specified": "A flag %[1]s depende de %[2]s que não foi especificada.",
         "goopt.error.dependency_on_empty_flag": "não é possível definir dependência em flag vazia",
         "goopt.error.dependency_value_not_specified": "A flag %[1]s depende de %[2]s com valor %[3]s que não foi especificado. (recebido %[4]q)",

--- a/v2/i18n/locales/pt/pt_gen.go
+++ b/v2/i18n/locales/pt/pt_gen.go
@@ -105,6 +105,7 @@ const SystemTranslations = `{
         "goopt.error.required_flag": "flag obrigatória ausente: %[1]s",
         "goopt.error.required_positional_flag": "argumento posicional obrigatório ausente %[1]s na posição %[2]d",
         "goopt.error.required_when": "%[1]s é obrigatório quando %[2]s é usado",
+        "goopt.error.required_with_default": "a flag %[1]q não pode ser obrigatória e ter um valor padrão ao mesmo tempo (um valor padrão faz com que nunca esteja ausente)",
         "goopt.error.secure_flag_expects_value": "a flag segura %[1]s espera um valor, mas falhamos em obtê-lo",
         "goopt.error.setting_bound_variable_value": "erro ao definir valor da variável vinculada para a flag %[1]s",
         "goopt.error.short_flag_conflict": "flag curta '%[1]s' na flag global %[2]s já existe como %[3]v",

--- a/v2/i18n/locales/zh/zh_gen.go
+++ b/v2/i18n/locales/zh/zh_gen.go
@@ -105,6 +105,7 @@ const SystemTranslations = `{
         "goopt.error.required_flag": "缺少必需的标志: %[1]s",
         "goopt.error.required_positional_flag": "在索引 %[2]d 处缺少必需的位置参数 %[1]s",
         "goopt.error.required_when": "使用 %[2]s 时需要 %[1]s",
+        "goopt.error.required_with_default": "标志 %[1]q 不能既是必需的又具有默认值（默认值使其永远不会缺失）",
         "goopt.error.secure_flag_expects_value": "安全标志 %[1]s 需要一个值，但我们未能获取",
         "goopt.error.setting_bound_variable_value": "为标志 %[1]s 设置绑定变量值时出错",
         "goopt.error.short_flag_conflict": "全局标志 %[2]s 上的短标志 '%[1]s' 已作为 %[3]v 存在",

--- a/v2/i18n/locales/zh/zh_gen.go
+++ b/v2/i18n/locales/zh/zh_gen.go
@@ -20,6 +20,7 @@ const SystemTranslations = `{
         "goopt.error.configuring_parser": "配置解析器时出错",
         "goopt.error.conflicting_flags": "%[1]s 和 %[2]s 不能同时使用",
         "goopt.error.contract_args": "契约 %[1]q 的参数数量不正确",
+        "goopt.error.default_in_exclusive_group": "标志 %[1]q 属于互斥组（mutex/exactlyone），因此不能有默认值",
         "goopt.error.dependency_not_specified": "标志 %[1]s 依赖于未指定的 %[2]s。",
         "goopt.error.dependency_on_empty_flag": "无法在空标志上指定依赖关系",
         "goopt.error.dependency_value_not_specified": "标志 %[1]s 依赖于带有值 %[3]s 的 %[2]s，但未指定。(得到 %[4]q)",

--- a/v2/interaction_matrix_test.go
+++ b/v2/interaction_matrix_test.go
@@ -339,6 +339,73 @@ func TestInteractionMatrixTranslatedNames(t *testing.T) {
 	}
 }
 
+// TestInteractionMatrixTranslatedCommands is the command-path twin of the
+// translated-flag test: a command invoked by its localized name must resolve to
+// its canonical path — terminal, nested (translated parent + translated sub), and
+// mixed canonical/translated — and the canonical names must still work in the
+// non-English locale. Commands resolve through a different path (getCommand /
+// GetCanonicalCommandPath) than flags, so it gets its own coverage.
+func TestInteractionMatrixTranslatedCommands(t *testing.T) {
+	build := func(t *testing.T) *Parser {
+		p := NewParser()
+		b := i18n.NewEmptyBundle()
+		if err := b.AddLanguage(language.Spanish, map[string]string{
+			"cmd.status": "estado", "cmd.deploy": "desplegar", "cmd.service": "servicio",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := p.SetUserBundle(b); err != nil {
+			t.Fatal(err)
+		}
+		if err := p.SetLanguage(language.Spanish); err != nil {
+			t.Fatal(err)
+		}
+		// terminal command "status"
+		if err := p.AddCommand(NewCommand(WithName("status"), WithCommandNameKey("cmd.status"))); err != nil {
+			t.Fatal(err)
+		}
+		// nested: deploy -> service
+		sub := NewCommand(WithName("service"), WithCommandNameKey("cmd.service"))
+		if err := p.AddCommand(NewCommand(WithName("deploy"), WithCommandNameKey("cmd.deploy"), WithSubcommands(sub))); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	invoked := func(p *Parser, path string) bool {
+		for _, c := range p.GetCommands() {
+			if c == path {
+				return true
+			}
+		}
+		return false
+	}
+	check := func(t *testing.T, args []string, wantPath string) {
+		t.Helper()
+		p := build(t)
+		p.Parse(append([]string{os.Args[0]}, args...))
+		if errs := p.GetErrors(); len(errs) != 0 {
+			t.Fatalf("%v: unexpected errors: %v", args, errs)
+		}
+		if !invoked(p, wantPath) {
+			t.Errorf("%v did not invoke %q; commands=%v", args, wantPath, p.GetCommands())
+		}
+	}
+
+	t.Run("terminal by translated name", func(t *testing.T) {
+		check(t, []string{"estado"}, "status")
+	})
+	t.Run("nested by translated names", func(t *testing.T) {
+		check(t, []string{"desplegar", "servicio"}, "deploy service")
+	})
+	t.Run("mixed canonical parent + translated sub", func(t *testing.T) {
+		check(t, []string{"deploy", "servicio"}, "deploy service")
+	})
+	t.Run("canonical still works in the non-en locale", func(t *testing.T) {
+		check(t, []string{"deploy", "service"}, "deploy service")
+		check(t, []string{"status"}, "status")
+	})
+}
+
 // TestInteractionMatrixShortFlags crosses POSIX short-flag invocation (-x) with
 // scope. Short flags go through a separate parse path (parsePosixFlag) from long
 // flags, so this checks they resolve — and carry their constraints — identically

--- a/v2/interaction_matrix_test.go
+++ b/v2/interaction_matrix_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/napalu/goopt/v2/completion"
 	"github.com/napalu/goopt/v2/errs"
 	"github.com/napalu/goopt/v2/i18n"
 	"github.com/napalu/goopt/v2/i18n/locales/ar"
@@ -1248,4 +1249,83 @@ func TestInteractionMatrixExoticTyped(t *testing.T) {
 			t.Errorf("File flag value should be the file CONTENT; got %q", v)
 		}
 	})
+}
+
+// TestInteractionMatrixCompletionInheritance charts the completion × command-tree
+// seam: a completion script is a second representation of "which flags are valid
+// here", and it must agree with what the parser actually accepts. The parser inherits
+// a parent command's flags onto subcommands (parent-walking), so completion must
+// surface them there too — otherwise tab-completion under-suggests valid flags.
+func TestInteractionMatrixCompletionInheritance(t *testing.T) {
+	p := NewParser()
+	if err := p.AddFlag("verbose", newStandalone(WithShortFlag("v"))); err != nil { // global
+		t.Fatal(err)
+	}
+	start := NewCommand(WithName("start"))
+	server := NewCommand(WithName("server"), WithSubcommands(start))
+	if err := p.AddCommand(server); err != nil {
+		t.Fatal(err)
+	}
+	mustAddFlag(t, p, "port", NewArg(WithType(types.Single)), "server")             // owned by server
+	mustAddFlag(t, p, "timeout", NewArg(WithType(types.Single)), "server", "start") // owned by server start
+
+	has := func(fps []completion.FlagPair, long string) bool {
+		for _, f := range fps {
+			if f.Long == long {
+				return true
+			}
+		}
+		return false
+	}
+	d := p.GetCompletionData()
+
+	// server: own flag only (no descendant leakage upward).
+	if !has(d.CommandFlags["server"], "port") {
+		t.Errorf("server completion must offer its own --port; got %v", d.CommandFlags["server"])
+	}
+	if has(d.CommandFlags["server"], "timeout") {
+		t.Errorf("server must NOT offer the subcommand-only --timeout; got %v", d.CommandFlags["server"])
+	}
+	// server start: own flag PLUS the inherited parent flag — the regression.
+	if !has(d.CommandFlags["server start"], "timeout") {
+		t.Errorf("`server start` must offer its own --timeout; got %v", d.CommandFlags["server start"])
+	}
+	if !has(d.CommandFlags["server start"], "port") {
+		t.Errorf("`server start` must inherit parent's --port (parser accepts it there); got %v", d.CommandFlags["server start"])
+	}
+}
+
+// TestInteractionMatrixCompletionValues locks the FlagValues keying fix: value
+// completion (deprecated AcceptedValues) must reach the generators, which read the
+// BARE flag name. Previously values were stored only when a short flag existed and
+// command-scoped values were keyed "cmd@flag" — a key no generator reads — so value
+// completion was dead for long-only and command-scoped flags.
+func TestInteractionMatrixCompletionValues(t *testing.T) {
+	vals := func(pats ...string) []types.PatternValue {
+		out := make([]types.PatternValue, len(pats))
+		for i, pp := range pats {
+			out[i] = types.PatternValue{Pattern: pp, Description: pp}
+		}
+		return out
+	}
+	p := NewParser()
+	mustAddFlag(t, p, "mode", NewArg(WithType(types.Single), WithAcceptedValues(vals("fast", "slow")))) // global, no short
+	mustAddCmd(t, p, "run")
+	mustAddFlag(t, p, "level", NewArg(WithType(types.Single), WithShortFlag("l"), WithAcceptedValues(vals("hi", "lo"))), "run") // command-scoped
+
+	d := p.GetCompletionData()
+	if _, ok := d.FlagValues["mode"]; !ok {
+		t.Errorf("long-only global flag values must be keyed by bare long 'mode'; keys=%v", keysOf(d.FlagValues))
+	}
+	if _, ok := d.FlagValues["level"]; !ok {
+		t.Errorf("command-scoped flag values must be keyed by bare long 'level' (not 'run@level'); keys=%v", keysOf(d.FlagValues))
+	}
+}
+
+func keysOf(m map[string][]completion.CompletionValue) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }

--- a/v2/interaction_matrix_test.go
+++ b/v2/interaction_matrix_test.go
@@ -1293,6 +1293,26 @@ func TestInteractionMatrixCompletionInheritance(t *testing.T) {
 	if !has(d.CommandFlags["server start"], "port") {
 		t.Errorf("`server start` must inherit parent's --port (parser accepts it there); got %v", d.CommandFlags["server start"])
 	}
+
+	// Depth + short form: the walk must climb EVERY ancestor and preserve short flags.
+	// A grandparent flag (with a short) must reach a 3-level-deep terminal.
+	p2 := NewParser()
+	cc := NewCommand(WithName("c"))
+	bb := NewCommand(WithName("b"), WithSubcommands(cc))
+	if err := p2.AddCommand(NewCommand(WithName("a"), WithSubcommands(bb))); err != nil {
+		t.Fatal(err)
+	}
+	mustAddFlag(t, p2, "top", NewArg(WithType(types.Single), WithShortFlag("t")), "a") // grandparent + short
+	d2 := p2.GetCompletionData()
+	deep := d2.CommandFlags["a b c"]
+	if !has(deep, "top") {
+		t.Errorf("`a b c` must inherit grandparent's --top across two levels; got %v", deep)
+	}
+	for _, f := range deep {
+		if f.Long == "top" && f.Short != "t" {
+			t.Errorf("inherited --top must keep its short -t; got short=%q", f.Short)
+		}
+	}
 }
 
 // TestInteractionMatrixCompletionValues locks the FlagValues keying fix: value

--- a/v2/interaction_matrix_test.go
+++ b/v2/interaction_matrix_test.go
@@ -1,0 +1,617 @@
+package goopt
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/napalu/goopt/v2/errs"
+	"github.com/napalu/goopt/v2/i18n"
+	"github.com/napalu/goopt/v2/i18n/locales/ar"
+	"github.com/napalu/goopt/v2/types"
+	"github.com/napalu/goopt/v2/validation"
+	"golang.org/x/text/language"
+)
+
+// Interaction-matrix tests deliberately "hammer the edges": they cross each
+// constraint FEATURE against the DIMENSIONS where goopt bugs have historically
+// clustered — flag scope (global / command-scoped / inherited), cross-command
+// isolation, and rendering across locales — rather than testing each feature only
+// in its primary (global) dimension. The cells, not the features, are the target.
+
+// --- the WHERE axis: flag scope ---
+
+type matrixScope struct {
+	name     string
+	flagPath []string // command path the constrained flags are registered under (nil = global)
+	invoke   []string // command tokens that should activate them
+}
+
+var matrixScopes = []matrixScope{
+	{"global", nil, nil},
+	{"command", []string{"cmd"}, []string{"cmd"}},
+	{"inherited", []string{"cmd"}, []string{"cmd", "sub"}}, // flag on parent, invoked via subcommand
+}
+
+// registerMatrixCommands sets up `cmd` (with subcommand `sub`) plus a sibling
+// `other`, giving every scope and the cross-command isolation check what it needs.
+func registerMatrixCommands(t *testing.T, p *Parser, s matrixScope) {
+	t.Helper()
+	var cmd *Command
+	if len(s.invoke) > 1 {
+		// inherited scope: `cmd` owns the subcommand we invoke through, so the
+		// flags registered on `cmd` are reached via `cmd sub`.
+		cmd = NewCommand(WithName(s.invoke[0]), WithSubcommands(NewCommand(WithName(s.invoke[1]))))
+	} else {
+		// command scope: `cmd` is terminal (a mandatory subcommand would make a
+		// bare `cmd` invocation invalid).
+		cmd = NewCommand(WithName("cmd"))
+	}
+	if err := p.AddCommand(cmd); err != nil {
+		t.Fatalf("add cmd: %v", err)
+	}
+	if err := p.AddCommand(NewCommand(WithName("other"))); err != nil {
+		t.Fatalf("add other: %v", err)
+	}
+}
+
+// --- the WHAT axis: constraint features ---
+
+type matrixFeature struct {
+	name    string
+	setup   func(t *testing.T, p *Parser, path []string)
+	violate []string // flag tokens (after the command tokens) that must trip the constraint
+	satisfy []string // flag tokens that must satisfy it
+	wantErr error    // sentinel expected on violate (nil => "any error", e.g. validators)
+	warning bool     // constraint surfaces as a Warning (GetWarnings), not an Error
+}
+
+var matrixFeatures = []matrixFeature{
+	{
+		name: "required",
+		setup: func(t *testing.T, p *Parser, path []string) {
+			mustAddFlag(t, p, "alpha", NewArg(WithType(types.Single), WithRequired(true)), path...)
+		},
+		violate: nil,
+		satisfy: []string{"--alpha", "v"},
+		wantErr: errs.ErrRequiredFlag,
+	},
+	{
+		name: "validator",
+		setup: func(t *testing.T, p *Parser, path []string) {
+			mustAddFlag(t, p, "alpha", NewArg(WithType(types.Single), WithValidators(validation.MinLength(5))), path...)
+		},
+		violate: []string{"--alpha", "ab"},
+		satisfy: []string{"--alpha", "abcde"},
+		wantErr: nil, // validators wrap their own error; assert presence
+	},
+	{
+		name: "mutex",
+		setup: func(t *testing.T, p *Parser, path []string) {
+			mustAddFlag(t, p, "alpha", newStandalone(WithMutex("g")), path...)
+			mustAddFlag(t, p, "beta", newStandalone(WithMutex("g")), path...)
+		},
+		violate: []string{"--alpha", "--beta"},
+		satisfy: []string{"--alpha"},
+		wantErr: errs.ErrMutexViolation,
+	},
+	{
+		name: "exactlyone",
+		setup: func(t *testing.T, p *Parser, path []string) {
+			mustAddFlag(t, p, "alpha", newStandalone(WithExactlyOne("g")), path...)
+			mustAddFlag(t, p, "beta", newStandalone(WithExactlyOne("g")), path...)
+		},
+		violate: nil,
+		satisfy: []string{"--alpha"},
+		wantErr: errs.ErrExactlyOneRequired,
+	},
+	{
+		name: "conflicts",
+		setup: func(t *testing.T, p *Parser, path []string) {
+			mustAddFlag(t, p, "alpha", newStandalone(WithConflicts("beta")), path...)
+			mustAddFlag(t, p, "beta", newStandalone(), path...)
+		},
+		violate: []string{"--alpha", "--beta"},
+		satisfy: []string{"--alpha"},
+		wantErr: errs.ErrConflictingFlags,
+	},
+	{
+		name: "requires",
+		setup: func(t *testing.T, p *Parser, path []string) {
+			mustAddFlag(t, p, "alpha", newStandalone(WithRequires("beta")), path...)
+			mustAddFlag(t, p, "beta", newStandalone(), path...)
+		},
+		violate: []string{"--alpha"},
+		satisfy: []string{"--alpha", "--beta"},
+		wantErr: errs.ErrFlagRequires,
+	},
+	{
+		name: "requiredOn",
+		setup: func(t *testing.T, p *Parser, path []string) {
+			mustAddFlag(t, p, "trigger", newStandalone(), path...)
+			mustAddFlag(t, p, "token", NewArg(WithRequiredOn("trigger")), path...)
+		},
+		violate: []string{"--trigger"},
+		satisfy: []string{"--trigger", "--token", "x"},
+		wantErr: errs.ErrRequiredWhen,
+	},
+	{
+		name: "positional",
+		setup: func(t *testing.T, p *Parser, path []string) {
+			mustAddFlag(t, p, "pos0", NewArg(WithType(types.Single), WithPosition(0), WithRequired(true)), path...)
+		},
+		violate: nil,
+		satisfy: []string{"thevalue"},
+		wantErr: errs.ErrRequiredPositionalFlag,
+	},
+	{
+		name: "dependsOn",
+		setup: func(t *testing.T, p *Parser, path []string) {
+			mustAddFlag(t, p, "alpha", newStandalone(WithDependentFlags([]string{"beta"})), path...)
+			mustAddFlag(t, p, "beta", newStandalone(), path...)
+		},
+		violate: []string{"--alpha"},
+		satisfy: []string{"--alpha", "--beta"},
+		warning: true, // dependency unmet is warning-level, not an error
+	},
+}
+
+func newMatrixParser(t *testing.T, f matrixFeature, s matrixScope) *Parser {
+	t.Helper()
+	p := NewParser()
+	if len(s.flagPath) > 0 {
+		registerMatrixCommands(t, p, s)
+	}
+	f.setup(t, p, s.flagPath)
+	return p
+}
+
+// matrixArgs builds an argv exactly as a real program receives it: os.Args[0]
+// (the executable) followed by the command tokens and flags. Parse strips the
+// leading os.Args[0] via pruneExecPathFromArgs, just as it does in production —
+// using a fake program name here would leave it to be mis-bound as a positional.
+func matrixArgs(invoke, flags []string) []string {
+	args := append([]string{os.Args[0]}, invoke...)
+	return append(args, flags...)
+}
+
+func constraintTripped(p *Parser, f matrixFeature) bool {
+	if f.warning {
+		return len(p.GetWarnings()) > 0
+	}
+	if f.wantErr != nil {
+		return hasErr(p, f.wantErr)
+	}
+	return len(p.GetErrors()) > 0
+}
+
+// diagnostics returns the rendered user-facing messages for a feature's outcome
+// (warnings for warning-level features, errors otherwise).
+func diagnostics(p *Parser, f matrixFeature) []string {
+	if f.warning {
+		return p.GetWarnings()
+	}
+	var msgs []string
+	for _, e := range p.GetErrors() {
+		msgs = append(msgs, e.Error())
+	}
+	return msgs
+}
+
+func assertConstraint(t *testing.T, p *Parser, f matrixFeature, want bool, label string) {
+	t.Helper()
+	if got := constraintTripped(p, f); got != want {
+		t.Errorf("[%s] constraint tripped=%v, want %v; errors=%v", label, got, want, p.GetErrors())
+	}
+}
+
+// matrixKnownGaps records (feature/scope) cells that are intentionally not
+// supported, with the design rationale. Skipping — rather than deleting the cell —
+// keeps the decision visible and greppable.
+var matrixKnownGaps = map[string]string{
+	"positional/inherited": "BY DESIGN: positionals are command-local — they bind to their direct command only and are not inherited by subcommands. Unlike name-keyed flags, positionals are index-keyed, so inheritance would risk silent mis-binding (index collisions across levels) and erode the unknown-argument guard. For a value shared across subcommands, use a flag (which inherits) or declare the positional per-subcommand.",
+}
+
+// TestInteractionMatrix crosses every constraint feature with every scope and
+// asserts: it fires on violation, stays quiet when satisfied, and — for
+// command-scoped flags — does NOT fire when a different command is invoked.
+func TestInteractionMatrix(t *testing.T) {
+	for _, f := range matrixFeatures {
+		for _, s := range matrixScopes {
+			t.Run(f.name+"/"+s.name, func(t *testing.T) {
+				if reason, gap := matrixKnownGaps[f.name+"/"+s.name]; gap {
+					t.Skip(reason)
+				}
+				// 1. violate -> the constraint must fire
+				p := newMatrixParser(t, f, s)
+				p.Parse(matrixArgs(s.invoke, f.violate))
+				assertConstraint(t, p, f, true, "violate")
+
+				// 2. satisfy -> it must not fire
+				p = newMatrixParser(t, f, s)
+				p.Parse(matrixArgs(s.invoke, f.satisfy))
+				assertConstraint(t, p, f, false, "satisfy")
+
+				// 3. cross-command isolation: invoking a DIFFERENT command must not
+				//    trip a constraint declared on this command's flags.
+				if len(s.flagPath) > 0 {
+					p = newMatrixParser(t, f, s)
+					p.Parse([]string{"app", "other"})
+					assertConstraint(t, p, f, false, "isolation(other)")
+				}
+			})
+		}
+	}
+}
+
+// TestInteractionMatrixRendering crosses each feature's violation with locale
+// rendering (incl. RTL Arabic) and asserts the user-facing message is well-formed:
+// no %!(NOVERB/BADINDEX), no doubled or mixed quotes.
+func TestInteractionMatrixRendering(t *testing.T) {
+	langs := []struct {
+		tag  language.Tag
+		load bool
+	}{
+		{language.English, false},
+		{language.German, false}, // default-loaded
+		{ar.Tag, true},           // must be loaded explicitly (RTL)
+	}
+	for _, f := range matrixFeatures {
+		for _, l := range langs {
+			t.Run(f.name+"/"+l.tag.String(), func(t *testing.T) {
+				p := NewParser()
+				if l.load {
+					if err := p.GetSystemBundle().LoadFromString(ar.Tag, ar.SystemTranslations); err != nil {
+						t.Fatalf("load %s: %v", l.tag, err)
+					}
+				}
+				if err := p.SetLanguage(l.tag); err != nil {
+					t.Fatalf("set language %s: %v", l.tag, err)
+				}
+				cmdScope := matrixScopes[1] // command-scoped (terminal cmd)
+				registerMatrixCommands(t, p, cmdScope)
+				f.setup(t, p, cmdScope.flagPath)
+				p.Parse(matrixArgs(cmdScope.invoke, f.violate))
+
+				msgs := diagnostics(p, f)
+				if len(msgs) == 0 {
+					t.Fatalf("[%s] expected the violation to produce a diagnostic to render", l.tag)
+				}
+				for _, msg := range msgs {
+					for _, bad := range []string{"%!", "''", `"'`, `'"`} {
+						if strings.Contains(msg, bad) {
+							t.Errorf("[%s] %s: malformed render %q (marker %q)", l.tag, f.name, msg, bad)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestInteractionMatrixTranslatedNames crosses translated flag names (nameKey)
+// with scope: a flag invoked by its localized name must resolve to the canonical
+// flag whether global, command-scoped, or inherited — the i18n × parsing × commands
+// seam. The canonical name must keep working in the same locale.
+func TestInteractionMatrixTranslatedNames(t *testing.T) {
+	for _, s := range matrixScopes {
+		t.Run(s.name, func(t *testing.T) {
+			build := func() *Parser {
+				p := NewParser()
+				b := i18n.NewEmptyBundle()
+				if err := b.AddLanguage(language.Spanish, map[string]string{"flag.color": "tonalidad"}); err != nil {
+					t.Fatal(err)
+				}
+				if err := p.SetUserBundle(b); err != nil {
+					t.Fatal(err)
+				}
+				if err := p.SetLanguage(language.Spanish); err != nil {
+					t.Fatal(err)
+				}
+				if len(s.flagPath) > 0 {
+					registerMatrixCommands(t, p, s)
+				}
+				mustAddFlag(t, p, "color", NewArg(WithType(types.Single), WithNameKey("flag.color")), s.flagPath...)
+				return p
+			}
+
+			// Invoked by its translated name -> must set the canonical flag.
+			p := build()
+			p.Parse(matrixArgs(s.invoke, []string{"--tonalidad", "red"}))
+			if errs := p.GetErrors(); len(errs) != 0 {
+				t.Fatalf("translated name: unexpected errors: %v", errs)
+			}
+			if !p.HasFlag("color", s.flagPath...) {
+				t.Errorf("translated --tonalidad did not set canonical 'color'")
+			}
+
+			// Canonical name must still work in the same locale.
+			p = build()
+			p.Parse(matrixArgs(s.invoke, []string{"--color", "blue"}))
+			if errs := p.GetErrors(); len(errs) != 0 {
+				t.Fatalf("canonical name: unexpected errors: %v", errs)
+			}
+			if !p.HasFlag("color", s.flagPath...) {
+				t.Errorf("canonical --color did not set 'color'")
+			}
+		})
+	}
+}
+
+// TestInteractionMatrixShortFlags crosses POSIX short-flag invocation (-x) with
+// scope. Short flags go through a separate parse path (parsePosixFlag) from long
+// flags, so this checks they resolve — and carry their constraints — identically
+// across global / command / inherited scope.
+func TestInteractionMatrixShortFlags(t *testing.T) {
+	for _, s := range matrixScopes {
+		t.Run(s.name, func(t *testing.T) {
+			build := func() *Parser {
+				p := NewParser()
+				if len(s.flagPath) > 0 {
+					registerMatrixCommands(t, p, s)
+				}
+				mustAddFlag(t, p, "alpha", newStandalone(WithShortFlag("a"), WithMutex("g")), s.flagPath...)
+				mustAddFlag(t, p, "beta", newStandalone(WithShortFlag("b"), WithMutex("g")), s.flagPath...)
+				return p
+			}
+
+			// 1. a short flag sets its flag
+			p := build()
+			p.Parse(matrixArgs(s.invoke, []string{"-a"}))
+			if errs := p.GetErrors(); len(errs) != 0 {
+				t.Fatalf("-a: unexpected errors: %v", errs)
+			}
+			if !p.HasFlag("alpha", s.flagPath...) {
+				t.Errorf("-a did not set 'alpha'")
+			}
+
+			// 2. short flags carry the constraint: -a -b must trip the mutex
+			p = build()
+			p.Parse(matrixArgs(s.invoke, []string{"-a", "-b"}))
+			if !hasErr(p, errs.ErrMutexViolation) {
+				t.Errorf("-a -b: expected mutex violation, got %v", p.GetErrors())
+			}
+		})
+	}
+}
+
+// TestInteractionMatrixEnv crosses environment-variable resolution with scope. A
+// required flag with no command-line value should be satisfied by its env var —
+// and that resolution must work whether the flag is global, command-scoped, or
+// inherited. Both a plain and a hyphenated flag name are exercised (the hyphenated
+// shape is the one that historically failed to match the converter's output).
+func TestInteractionMatrixEnv(t *testing.T) {
+	// Maps a flag name to its env-var form: upper-case, hyphens -> underscores.
+	// Idempotent on its own output, so matching is stable on both sides.
+	conv := func(s string) string { return strings.ToUpper(strings.ReplaceAll(s, "-", "_")) }
+	cases := []struct{ flag, env string }{
+		{"envflag", "ENVFLAG"},   // plain
+		{"env-flag", "ENV_FLAG"}, // hyphenated (historical-bug shape)
+	}
+	for _, c := range cases {
+		for _, s := range matrixScopes {
+			t.Run(c.flag+"/"+s.name, func(t *testing.T) {
+				build := func() *Parser {
+					p := NewParser()
+					p.SetEnvNameConverter(conv)
+					if len(s.flagPath) > 0 {
+						registerMatrixCommands(t, p, s)
+					}
+					mustAddFlag(t, p, c.flag, NewArg(WithType(types.Single), WithRequired(true)), s.flagPath...)
+					return p
+				}
+
+				// env unset, no arg -> the required flag must fire
+				t.Run("unset", func(t *testing.T) {
+					p := build()
+					p.Parse(matrixArgs(s.invoke, nil))
+					if !hasErr(p, errs.ErrRequiredFlag) {
+						t.Errorf("env unset: expected required error, got %v", p.GetErrors())
+					}
+				})
+				// env set -> it must satisfy the required flag (no error)
+				t.Run("set", func(t *testing.T) {
+					t.Setenv(c.env, "fromenv")
+					p := build()
+					p.Parse(matrixArgs(s.invoke, nil))
+					if hasErr(p, errs.ErrRequiredFlag) {
+						t.Errorf("env %s set: required should be satisfied, got %v", c.env, p.GetErrors())
+					}
+				})
+			})
+		}
+	}
+}
+
+// envRoundtrip drives the struct-based env path: derived names where a field
+// becomes a flag (FlagNameConverter) whose value can be supplied via an env var.
+// Fields need tag content to register as flags (an empty `goopt:""` is "not a flag").
+type envRoundtrip struct {
+	GlobalVal string `goopt:"desc:global value"`
+	Cmd       struct {
+		CmdVal string   `goopt:"desc:command value"`
+		Sub    struct{} `goopt:"kind:command"`
+	} `goopt:"kind:command"`
+}
+
+// TestInteractionMatrixEnvStruct exercises the round-trip a real app wires: a field
+// becomes a flag via the FlagNameConverter, and an env var resolves to it via the
+// EnvNameConverter. By design the two converters must be the SAME — env matching
+// runs the env converter over both the env var name and the (already flag-named)
+// flag, so they match only when normalized to the same form. With ToKebabCase on
+// both, env `GLOBAL_VAL` and flag `global-val` both normalize to `global-val`.
+// Verified across global, command, and inherited scope.
+func TestInteractionMatrixEnvStruct(t *testing.T) {
+	newP := func(t *testing.T, cfg *envRoundtrip) *Parser {
+		t.Helper()
+		p, err := NewParserFromStruct(cfg,
+			WithFlagNameConverter(ToKebabCase), // GlobalVal -> global-val
+			WithEnvNameConverter(ToKebabCase),  // same converter, by design: GLOBAL_VAL & global-val both -> global-val
+		)
+		if err != nil {
+			t.Fatalf("NewParserFromStruct: %v", err)
+		}
+		return p
+	}
+
+	// GlobalVal -> --global-val -> $GLOBAL_VAL (global scope)
+	t.Run("global", func(t *testing.T) {
+		t.Setenv("GLOBAL_VAL", "fromenv")
+		cfg := &envRoundtrip{}
+		p := newP(t, cfg)
+		p.Parse([]string{os.Args[0]})
+		if cfg.GlobalVal != "fromenv" {
+			t.Errorf("GlobalVal = %q, want %q (round-trip GlobalVal->global-val->GLOBAL_VAL); errs=%v",
+				cfg.GlobalVal, "fromenv", p.GetErrors())
+		}
+	})
+
+	// Cmd.CmdVal -> --cmd-val -> $CMD_VAL, resolved when `cmd` is invoked.
+	t.Run("command", func(t *testing.T) {
+		t.Setenv("CMD_VAL", "fromenv")
+		cfg := &envRoundtrip{}
+		p := newP(t, cfg)
+		p.Parse([]string{os.Args[0], "cmd"})
+		if cfg.Cmd.CmdVal != "fromenv" {
+			t.Errorf("Cmd.CmdVal = %q, want %q; errs=%v", cfg.Cmd.CmdVal, "fromenv", p.GetErrors())
+		}
+	})
+
+	// Same field reached via a subcommand invocation (inherited scope).
+	t.Run("inherited", func(t *testing.T) {
+		t.Setenv("CMD_VAL", "fromenv")
+		cfg := &envRoundtrip{}
+		p := newP(t, cfg)
+		p.Parse([]string{os.Args[0], "cmd", "sub"})
+		if cfg.Cmd.CmdVal != "fromenv" {
+			t.Errorf("Cmd.CmdVal = %q, want %q (inherited via `cmd sub`); errs=%v",
+				cfg.Cmd.CmdVal, "fromenv", p.GetErrors())
+		}
+	})
+}
+
+// TestInteractionMatrixDefaults crosses default-value semantics with scope, locking
+// three behaviors (and checking scope doesn't change them):
+//   - `required` + `default` is a contradictory declaration, rejected at
+//     construction (Design B) — a default makes the flag never "missing";
+//   - a bad default is NOT run through validators (defaults are trusted);
+//   - a provided value IS validated and overrides the default.
+func TestInteractionMatrixDefaults(t *testing.T) {
+	for _, s := range matrixScopes {
+		t.Run(s.name, func(t *testing.T) {
+			mk := func(t *testing.T) *Parser {
+				p := NewParser()
+				if len(s.flagPath) > 0 {
+					registerMatrixCommands(t, p, s)
+				}
+				return p
+			}
+
+			// (A) required + default is contradictory -> rejected at construction.
+			t.Run("required_plus_default_is_rejected", func(t *testing.T) {
+				p := mk(t)
+				err := p.AddFlag("req", NewArg(WithType(types.Single), WithDefaultValue("d"), WithRequired(true)), s.flagPath...)
+				if !errors.Is(err, errs.ErrRequiredWithDefault) {
+					t.Errorf("required+default should be rejected at construction; got %v", err)
+				}
+			})
+
+			// (B) bad default, no value -> validators are NOT run on the default.
+			t.Run("bad_default_bypasses_validators", func(t *testing.T) {
+				p := mk(t)
+				mustAddFlag(t, p, "val", NewArg(WithType(types.Single), WithDefaultValue("ab"), WithValidators(validation.MinLength(5))), s.flagPath...)
+				p.Parse(matrixArgs(s.invoke, nil))
+				if len(p.GetErrors()) != 0 {
+					t.Errorf("a bad default should bypass validators (no error); got %v", p.GetErrors())
+				}
+			})
+
+			// (C) a provided value that violates the validator IS caught (and the
+			//     value path runs validation even though a default exists).
+			t.Run("provided_value_is_validated", func(t *testing.T) {
+				p := mk(t)
+				mustAddFlag(t, p, "val", NewArg(WithType(types.Single), WithDefaultValue("ab"), WithValidators(validation.MinLength(5))), s.flagPath...)
+				p.Parse(matrixArgs(s.invoke, []string{"--val", "abc"})) // len 3 < 5
+				if len(p.GetErrors()) == 0 {
+					t.Errorf("a provided value violating the validator should error; got none")
+				}
+			})
+		})
+	}
+}
+
+// TestInteractionMatrixPrecedence verifies the DOCUMENTED configuration precedence
+// (default < env < config(ParseWithDefaults) < command line) actually holds in the
+// implementation — in particular config-over-env, which the injection mechanism
+// (both arrive as synthetic args) does not obviously guarantee.
+func TestInteractionMatrixPrecedence(t *testing.T) {
+	conv := func(s string) string { return strings.ToUpper(strings.ReplaceAll(s, "-", "_")) }
+	build := func() *Parser {
+		p := NewParser()
+		p.SetEnvNameConverter(conv)
+		_ = p.AddFlag("port", NewArg(WithType(types.Single), WithDefaultValue("8080")))
+		return p
+	}
+	get := func(p *Parser) string { return p.GetOrDefault("port", "") }
+
+	t.Run("default only", func(t *testing.T) {
+		p := build()
+		p.Parse([]string{os.Args[0]})
+		if g := get(p); g != "8080" {
+			t.Errorf("got %q, want 8080 (default)", g)
+		}
+	})
+	t.Run("env over default", func(t *testing.T) {
+		t.Setenv("PORT", "9000")
+		p := build()
+		p.Parse([]string{os.Args[0]})
+		if g := get(p); g != "9000" {
+			t.Errorf("got %q, want 9000 (env > default)", g)
+		}
+	})
+	t.Run("config over env", func(t *testing.T) {
+		t.Setenv("PORT", "9000")
+		p := build()
+		p.ParseWithDefaults(map[string]string{"port": "7000"}, []string{os.Args[0]})
+		if g := get(p); g != "7000" {
+			t.Errorf("got %q, want 7000 (config > env per docs)", g)
+		}
+	})
+	t.Run("command line over all", func(t *testing.T) {
+		t.Setenv("PORT", "9000")
+		p := build()
+		p.ParseWithDefaults(map[string]string{"port": "7000"}, []string{os.Args[0], "--port", "3000"})
+		if g := get(p); g != "3000" {
+			t.Errorf("got %q, want 3000 (cmdline > all)", g)
+		}
+	})
+}
+
+// TestInteractionMatrixBindDefault locks that a configured default is written to
+// the bound target for BOTH direct BindFlag and struct binding (BindFlag used to
+// leave the bound var empty), and that a provided value overrides it.
+func TestInteractionMatrixBindDefault(t *testing.T) {
+	t.Run("BindFlag writes default to bound var", func(t *testing.T) {
+		var v string
+		p := NewParser()
+		if err := p.BindFlag(&v, "f", NewArg(WithType(types.Single), WithDefaultValue("d"))); err != nil {
+			t.Fatal(err)
+		}
+		p.Parse([]string{os.Args[0]})
+		if v != "d" {
+			t.Errorf("BindFlag default: bound=%q, want %q", v, "d")
+		}
+	})
+	t.Run("provided value overrides the default", func(t *testing.T) {
+		var v string
+		p := NewParser()
+		if err := p.BindFlag(&v, "f", NewArg(WithType(types.Single), WithDefaultValue("d"))); err != nil {
+			t.Fatal(err)
+		}
+		p.Parse([]string{os.Args[0], "--f", "x"})
+		if v != "x" {
+			t.Errorf("override: bound=%q, want %q", v, "x")
+		}
+	})
+}

--- a/v2/interaction_matrix_test.go
+++ b/v2/interaction_matrix_test.go
@@ -3,8 +3,11 @@ package goopt
 import (
 	"errors"
 	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/napalu/goopt/v2/errs"
 	"github.com/napalu/goopt/v2/i18n"
@@ -987,6 +990,262 @@ func TestInteractionMatrixDeepNesting(t *testing.T) {
 		}
 		if v, _ := p.Get("dup", "a", "b"); v != "mid" {
 			t.Errorf("the parent's dup should keep its default 'mid', untouched; got %q", v)
+		}
+	})
+}
+
+// TestInteractionMatrixTypedFlags charts the Chained (list) value type, which the
+// constraint matrix never exercised. It locks the two bugs found at the
+// list × {repeated, custom-delimiter, bound-vs-unbound} seam:
+//
+//	A — a custom ListDelimiterFunc made GetList mangle the list (the internal
+//	    occurrence marker leaked into an element), diverging from the bound slice.
+//	B — repeated occurrences of an UNBOUND chained flag silently dropped all but the
+//	    last (accumulation was coupled to having a bound variable).
+//
+// The invariant under test: GetList (unbound) and a bound []string must return the
+// SAME list in every cell, and the user's declared separator is honoured for element
+// separation while repeated occurrences still accumulate.
+func TestInteractionMatrixTypedFlags(t *testing.T) {
+	want := []string{"a", "b", "c", "d"}
+
+	t.Run("unbound repeated accumulates (default delimiter)", func(t *testing.T) {
+		p := NewParser()
+		mustAddFlag(t, p, "v", NewArg(WithType(types.Chained)))
+		p.Parse([]string{"--v", "a,b", "--v", "c,d"})
+		got, err := p.GetList("v")
+		if err != nil || !slices.Equal(got, want) {
+			t.Errorf("unbound repeated should accumulate to %v; got %v (err=%v)", want, got, err)
+		}
+	})
+
+	t.Run("unbound repeated accumulates (custom ';' delimiter)", func(t *testing.T) {
+		p := NewParser()
+		if err := p.SetListDelimiterFunc(func(r rune) bool { return r == ';' }); err != nil {
+			t.Fatal(err)
+		}
+		mustAddFlag(t, p, "v", NewArg(WithType(types.Chained)))
+		p.Parse([]string{"--v", "a;b", "--v", "c;d"})
+		got, err := p.GetList("v")
+		if err != nil || !slices.Equal(got, want) {
+			t.Errorf("custom-delimiter unbound list should be %v; got %v (err=%v)", want, got, err)
+		}
+	})
+
+	t.Run("bound []string and GetList agree under a custom delimiter", func(t *testing.T) {
+		var bound []string
+		p := NewParser()
+		if err := p.SetListDelimiterFunc(func(r rune) bool { return r == ';' }); err != nil {
+			t.Fatal(err)
+		}
+		if err := p.BindFlag(&bound, "v", NewArg(WithType(types.Chained))); err != nil {
+			t.Fatal(err)
+		}
+		p.Parse([]string{"--v", "a;b", "--v", "c;d"})
+		got, _ := p.GetList("v")
+		if !slices.Equal(bound, want) {
+			t.Errorf("bound slice should be %v; got %v", want, bound)
+		}
+		if !slices.Equal(got, bound) {
+			t.Errorf("GetList must equal the bound slice; GetList=%v bound=%v", got, bound)
+		}
+	})
+
+	t.Run("single token splits on the user delimiter, not the internal marker", func(t *testing.T) {
+		p := NewParser()
+		if err := p.SetListDelimiterFunc(func(r rune) bool { return r == ';' }); err != nil {
+			t.Fatal(err)
+		}
+		mustAddFlag(t, p, "v", NewArg(WithType(types.Chained)))
+		p.Parse([]string{"--v", "a;b"})
+		if got, _ := p.GetList("v"); !slices.Equal(got, []string{"a", "b"}) {
+			t.Errorf("single token should split to [a b]; got %v", got)
+		}
+	})
+
+	t.Run("per-element validators run on each list element", func(t *testing.T) {
+		mk := func() *Parser {
+			p := NewParser()
+			if err := p.SetListDelimiterFunc(func(r rune) bool { return r == ';' }); err != nil {
+				t.Fatal(err)
+			}
+			mustAddFlag(t, p, "v", NewArg(WithType(types.Chained), WithValidators(validation.MinLength(2))))
+			return p
+		}
+		// every element satisfies MinLength(2), across a repeat → accumulates clean
+		p := mk()
+		p.Parse([]string{"--v", "ab;cd", "--v", "ef"})
+		if got, _ := p.GetList("v"); !slices.Equal(got, []string{"ab", "cd", "ef"}) {
+			t.Errorf("validated list should be [ab cd ef]; got %v", got)
+		}
+		// a single bad element (len 1) trips the validator
+		p = mk()
+		p.Parse([]string{"--v", "ab;x"})
+		if len(p.GetErrors()) == 0 {
+			t.Errorf("element 'x' (<2) should fail MinLength; got no error")
+		}
+	})
+
+	t.Run("Get returns a representation without a control byte leaking", func(t *testing.T) {
+		p := NewParser()
+		if err := p.SetListDelimiterFunc(func(r rune) bool { return r == ';' }); err != nil {
+			t.Fatal(err)
+		}
+		mustAddFlag(t, p, "v", NewArg(WithType(types.Chained)))
+		p.Parse([]string{"--v", "a;b", "--v", "c;d"})
+		raw, _ := p.Get("v")
+		if strings.ContainsRune(raw, '\x1f') {
+			t.Errorf("Get must not leak the internal marker; got %q", raw)
+		}
+	})
+}
+
+// TestInteractionMatrixExoticTyped charts the typed value types: scalar conversion
+// (time.Duration, time.Time), typed slices (which auto-infer to Chained and convert
+// per element — crossing directly through the chained-list refactor), and the File
+// type (whose value is the file's CONTENT, not its path). The seam of interest is
+// typed-slice × {custom delimiter, repeated}: per-element conversion must ride the
+// same (user delimiter ∪ internal marker) recovery the string path uses.
+func TestInteractionMatrixExoticTyped(t *testing.T) {
+	t.Run("BindFlag infers the option type from the bound variable", func(t *testing.T) {
+		// Regression: AddFlag's Empty->Single default used to run before BindFlag's
+		// inference, silently turning every bound slice into a scalar and every bound
+		// bool into a value-flag. Inference now runs first.
+		var ports []int
+		var verbose bool
+		var name string
+		p := NewParser()
+		if err := p.BindFlag(&ports, "port", NewArg()); err != nil {
+			t.Fatal(err)
+		}
+		if err := p.BindFlag(&verbose, "verbose", NewArg()); err != nil {
+			t.Fatal(err)
+		}
+		if err := p.BindFlag(&name, "name", NewArg()); err != nil {
+			t.Fatal(err)
+		}
+		for _, tc := range []struct {
+			flag string
+			want types.OptionType
+		}{
+			{"port", types.Chained},       // []int → list
+			{"verbose", types.Standalone}, // bool → presence-flag
+			{"name", types.Single},        // string → scalar
+		} {
+			arg, err := p.GetArgument(tc.flag)
+			if err != nil {
+				t.Fatalf("GetArgument(%s): %v", tc.flag, err)
+			}
+			if arg.TypeOf != tc.want {
+				t.Errorf("%s inferred TypeOf=%v, want %v", tc.flag, arg.TypeOf, tc.want)
+			}
+		}
+	})
+
+	t.Run("time.Duration scalar infers Single and parses", func(t *testing.T) {
+		var d time.Duration
+		p := NewParser()
+		if err := p.BindFlag(&d, "timeout", NewArg()); err != nil { // type inferred
+			t.Fatal(err)
+		}
+		p.Parse([]string{"--timeout", "1m30s"})
+		if d != 90*time.Second {
+			t.Errorf("timeout should parse to 90s; got %v", d)
+		}
+	})
+
+	t.Run("time.Time scalar infers Single and parses", func(t *testing.T) {
+		var ts time.Time
+		p := NewParser()
+		if err := p.BindFlag(&ts, "since", NewArg()); err != nil {
+			t.Fatal(err)
+		}
+		p.Parse([]string{"--since", "2026-06-20"})
+		if ts.Year() != 2026 || ts.Month() != time.June || ts.Day() != 20 {
+			t.Errorf("since should parse to 2026-06-20; got %v", ts)
+		}
+	})
+
+	t.Run("[]int slice infers Chained and converts per element (default delimiter)", func(t *testing.T) {
+		var ports []int
+		p := NewParser()
+		if err := p.BindFlag(&ports, "port", NewArg()); err != nil {
+			t.Fatal(err)
+		}
+		p.Parse([]string{"--port", "80,443", "--port", "8080"})
+		if !slices.Equal(ports, []int{80, 443, 8080}) {
+			t.Errorf("ports should accumulate+convert to [80 443 8080]; got %v", ports)
+		}
+	})
+
+	t.Run("[]int slice converts per element under a CUSTOM delimiter + repeat", func(t *testing.T) {
+		// This is the cell crossing the chained refactor: per-element typed conversion
+		// must split on (user ';' ∪ internal marker), same as GetList.
+		var ports []int
+		p := NewParser()
+		if err := p.SetListDelimiterFunc(func(r rune) bool { return r == ';' }); err != nil {
+			t.Fatal(err)
+		}
+		if err := p.BindFlag(&ports, "port", NewArg()); err != nil {
+			t.Fatal(err)
+		}
+		p.Parse([]string{"--port", "80;443", "--port", "8080"})
+		if !slices.Equal(ports, []int{80, 443, 8080}) {
+			t.Errorf("custom-delimiter typed slice should be [80 443 8080]; got %v (errs=%v)", ports, p.GetErrors())
+		}
+	})
+
+	t.Run("[]time.Duration slice converts per element across a repeat", func(t *testing.T) {
+		var durs []time.Duration
+		p := NewParser()
+		if err := p.BindFlag(&durs, "wait", NewArg()); err != nil {
+			t.Fatal(err)
+		}
+		p.Parse([]string{"--wait", "5s,2h", "--wait", "90m"})
+		want := []time.Duration{5 * time.Second, 2 * time.Hour, 90 * time.Minute}
+		if !slices.Equal(durs, want) {
+			t.Errorf("durations should be %v; got %v (errs=%v)", want, durs, p.GetErrors())
+		}
+	})
+
+	t.Run("numeric validator + typed slice + custom delimiter validates and converts per element", func(t *testing.T) {
+		// The capstone cross: per-element VALIDATION and per-element typed CONVERSION
+		// both ride (user ';' ∪ internal marker), across a repeat. Numeric validators
+		// parse the string before comparing, so there is no lexical-comparison trap.
+		mk := func() (*Parser, *[]int) {
+			var ports []int
+			p := NewParser()
+			if err := p.SetListDelimiterFunc(func(r rune) bool { return r == ';' }); err != nil {
+				t.Fatal(err)
+			}
+			if err := p.BindFlag(&ports, "port", NewArg(WithType(types.Chained), WithValidators(validation.IntRange(1, 100)))); err != nil {
+				t.Fatal(err)
+			}
+			return p, &ports
+		}
+		p, ports := mk()
+		p.Parse([]string{"--port", "10;20", "--port", "30"})
+		if !slices.Equal(*ports, []int{10, 20, 30}) || len(p.GetErrors()) != 0 {
+			t.Errorf("all-in-range should give [10 20 30] no error; got %v errs=%v", *ports, p.GetErrors())
+		}
+		p2, _ := mk()
+		p2.Parse([]string{"--port", "10;200"})
+		if !hasErr(p2, errs.ErrValueBetween) {
+			t.Errorf("element 200 should trip IntRange; got %v", p2.GetErrors())
+		}
+	})
+
+	t.Run("File type yields the file's content as the value", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "secret.txt")
+		if err := os.WriteFile(path, []byte("s3cr3t-token"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		p := NewParser()
+		mustAddFlag(t, p, "creds", NewArg(WithType(types.File)))
+		p.Parse([]string{"--creds", path})
+		if v, _ := p.Get("creds"); v != "s3cr3t-token" {
+			t.Errorf("File flag value should be the file CONTENT; got %q", v)
 		}
 	})
 }

--- a/v2/interaction_matrix_test.go
+++ b/v2/interaction_matrix_test.go
@@ -865,3 +865,128 @@ func TestInteractionMatrixMultipleCommands(t *testing.T) {
 		}
 	})
 }
+
+// TestInteractionMatrixDeepNesting charts the 3-level command axis. The rest of
+// the matrix tops out at two levels (`cmd` / `cmd sub`); a third level exposes
+// seams that only appear past depth 2: parent-walk flag resolution that must climb
+// TWO ancestors, cross-level contract targets, and command-scoping (`isActive`)
+// at depth, where a deep terminal's constraints must stay off for sibling branches.
+//
+// Command tree:
+//
+//	a
+//	├── b
+//	│   ├── c   (terminal)
+//	│   └── d   (terminal)
+//	└── e       (terminal)
+func TestInteractionMatrixDeepNesting(t *testing.T) {
+	// build constructs the tree afresh; opts registers the subtest's flags.
+	build := func(t *testing.T, opts func(p *Parser)) *Parser {
+		t.Helper()
+		p := NewParser()
+		c := NewCommand(WithName("c"))
+		d := NewCommand(WithName("d"))
+		e := NewCommand(WithName("e"))
+		b := NewCommand(WithName("b"), WithSubcommands(c, d))
+		a := NewCommand(WithName("a"), WithSubcommands(b, e))
+		if err := p.AddCommand(a); err != nil {
+			t.Fatalf("add a: %v", err)
+		}
+		if opts != nil {
+			opts(p)
+		}
+		return p
+	}
+
+	t.Run("level-1/2/3 flags all resolve when the deepest command is invoked", func(t *testing.T) {
+		p := build(t, func(p *Parser) {
+			mustAddFlag(t, p, "top", NewArg(WithType(types.Single)), "a")
+			mustAddFlag(t, p, "mid", NewArg(WithType(types.Single)), "a", "b")
+			mustAddFlag(t, p, "leaf", NewArg(WithType(types.Single)), "a", "b", "c")
+		})
+		p.Parse([]string{os.Args[0], "a", "b", "c", "--top", "T", "--mid", "M", "--leaf", "L"})
+		if e := p.GetErrors(); len(e) != 0 {
+			t.Fatalf("clean deep parse should have no errors; got %v", e)
+		}
+		// Each token binds to its OWNING command, proving the parser climbed up to
+		// two ancestors to resolve `top` (on a) and one for `mid` (on a b).
+		for _, tc := range []struct {
+			name string
+			path []string
+			want string
+		}{
+			{"top", []string{"a"}, "T"},
+			{"mid", []string{"a", "b"}, "M"},
+			{"leaf", []string{"a", "b", "c"}, "L"},
+		} {
+			if v, ok := p.Get(tc.name, tc.path...); !ok || v != tc.want {
+				t.Errorf("%s@%v: got (%q,%v), want %q", tc.name, tc.path, v, ok, tc.want)
+			}
+		}
+	})
+
+	t.Run("requires on a level-3 flag resolves its target on a level-1 ancestor", func(t *testing.T) {
+		mk := func() *Parser {
+			return build(t, func(p *Parser) {
+				mustAddFlag(t, p, "top", NewArg(WithType(types.Single)), "a")
+				mustAddFlag(t, p, "leaf", newStandalone(WithRequires("top")), "a", "b", "c")
+			})
+		}
+		// leaf set, target two levels up absent → requires must fire.
+		p := mk()
+		p.Parse([]string{os.Args[0], "a", "b", "c", "--leaf"})
+		if !hasErr(p, errs.ErrFlagRequires) {
+			t.Errorf("leaf requires top (two levels up); want ErrFlagRequires, got %v", p.GetErrors())
+		}
+		// target supplied → satisfied.
+		p = mk()
+		p.Parse([]string{os.Args[0], "a", "b", "c", "--leaf", "--top", "T"})
+		if hasErr(p, errs.ErrFlagRequires) {
+			t.Errorf("top supplied; requires should be satisfied, got %v", p.GetErrors())
+		}
+	})
+
+	t.Run("a deep terminal's required flag stays inactive for sibling branches", func(t *testing.T) {
+		mk := func() *Parser {
+			return build(t, func(p *Parser) {
+				mustAddFlag(t, p, "needc", NewArg(WithType(types.Single), WithRequired(true)), "a", "b", "c")
+			})
+		}
+		// sibling leaf under the same parent: `a b d` must not demand `a b c`'s flag.
+		p := mk()
+		p.Parse([]string{os.Args[0], "a", "b", "d"})
+		if hasErr(p, errs.ErrRequiredFlag) {
+			t.Errorf("invoking sibling `a b d` must not require a flag of `a b c`; got %v", p.GetErrors())
+		}
+		// different level-2 branch entirely: `a e` must not demand it either.
+		p = mk()
+		p.Parse([]string{os.Args[0], "a", "e"})
+		if hasErr(p, errs.ErrRequiredFlag) {
+			t.Errorf("invoking `a e` must not require a flag of `a b c`; got %v", p.GetErrors())
+		}
+		// the owning terminal itself, flag omitted → must fire.
+		p = mk()
+		p.Parse([]string{os.Args[0], "a", "b", "c"})
+		if !hasErr(p, errs.ErrRequiredFlag) {
+			t.Errorf("invoking `a b c` without needc should require it; got %v", p.GetErrors())
+		}
+	})
+
+	t.Run("nearest-ancestor wins when a child redefines an inherited flag", func(t *testing.T) {
+		p := build(t, nil)
+		if err := p.AddFlag("dup", NewArg(WithType(types.Single), WithDefaultValue("mid")), "a", "b"); err != nil {
+			t.Fatalf("add dup@'a b': %v", err)
+		}
+		// A child redefining a parent's flag name is the documented override case.
+		if err := p.AddFlag("dup", NewArg(WithType(types.Single), WithDefaultValue("leaf")), "a", "b", "c"); err != nil {
+			t.Skipf("child override of an inherited flag rejected at build time: %v", err)
+		}
+		p.Parse([]string{os.Args[0], "a", "b", "c", "--dup", "X"})
+		if v, ok := p.Get("dup", "a", "b", "c"); !ok || v != "X" {
+			t.Errorf("the leaf's own dup should receive X (nearest ancestor wins); got (%q,%v)", v, ok)
+		}
+		if v, _ := p.Get("dup", "a", "b"); v != "mid" {
+			t.Errorf("the parent's dup should keep its default 'mid', untouched; got %q", v)
+		}
+	})
+}

--- a/v2/interaction_matrix_test.go
+++ b/v2/interaction_matrix_test.go
@@ -733,3 +733,75 @@ func TestInteractionMatrixSecureEnv(t *testing.T) {
 		}
 	})
 }
+
+// TestInteractionMatrixHooks crosses the execution-lifecycle dimension: global vs
+// command pre/post hooks, hook ordering, and error short-circuiting. It locks the
+// observed (and coherent) model — onion ordering (pre outer->inner, post
+// inner->outer, mirrored by SetHookOrder) and defer-style errors (a pre-hook error
+// aborts the command but post-hooks still run with the error; a command error
+// propagates to every post-hook).
+func TestInteractionMatrixHooks(t *testing.T) {
+	es := func(e error) string {
+		if e == nil {
+			return "ok"
+		}
+		return "err"
+	}
+	// build wires global+command pre/post hooks and the command callback to append
+	// to a shared trace; preErr/cmdErr inject failures at the pre-hook / command.
+	build := func(t *testing.T, order HookOrder, preErr, cmdErr bool) (*Parser, *[]string) {
+		t.Helper()
+		var tr []string
+		add := func(s string) { tr = append(tr, s) }
+		p := NewParser()
+		p.SetHookOrder(order)
+		cmd := NewCommand(WithName("run"), WithCallback(func(p *Parser, c *Command) error {
+			add("cmd")
+			if cmdErr {
+				return errors.New("cmd failed")
+			}
+			return nil
+		}))
+		if err := p.AddCommand(cmd); err != nil {
+			t.Fatal(err)
+		}
+		p.AddGlobalPreHook(func(p *Parser, c *Command) error {
+			add("gPre")
+			if preErr {
+				return errors.New("gpre failed")
+			}
+			return nil
+		})
+		p.AddCommandPreHook("run", func(p *Parser, c *Command) error { add("cPre"); return nil })
+		p.AddCommandPostHook("run", func(p *Parser, c *Command, e error) error { add("cPost:" + es(e)); return nil })
+		p.AddGlobalPostHook(func(p *Parser, c *Command, e error) error { add("gPost:" + es(e)); return nil })
+		return p, &tr
+	}
+	trace := func(t *testing.T, order HookOrder, preErr, cmdErr bool) string {
+		t.Helper()
+		p, tr := build(t, order, preErr, cmdErr)
+		p.Parse([]string{os.Args[0], "run"})
+		p.ExecuteCommands()
+		return strings.Join(*tr, " ")
+	}
+
+	cases := []struct {
+		name   string
+		order  HookOrder
+		preErr bool
+		cmdErr bool
+		want   string
+	}{
+		{"global-first ordering", OrderGlobalFirst, false, false, "gPre cPre cmd cPost:ok gPost:ok"},
+		{"command-first mirrors it", OrderCommandFirst, false, false, "cPre gPre cmd gPost:ok cPost:ok"},
+		{"pre-hook error aborts command, post-hooks still run with error", OrderGlobalFirst, true, false, "gPre cPost:err gPost:err"},
+		{"command error propagates to post-hooks", OrderGlobalFirst, false, true, "gPre cPre cmd cPost:err gPost:err"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := trace(t, c.order, c.preErr, c.cmdErr); got != c.want {
+				t.Errorf("hook trace:\n got:  %s\n want: %s", got, c.want)
+			}
+		})
+	}
+}

--- a/v2/interaction_matrix_test.go
+++ b/v2/interaction_matrix_test.go
@@ -517,6 +517,18 @@ func TestInteractionMatrixDefaults(t *testing.T) {
 				}
 			})
 
+			// (A2) a default on a mutex/exactlyone member is meaningless -> rejected.
+			t.Run("default_on_exclusive_member_is_rejected", func(t *testing.T) {
+				p := mk(t)
+				if err := p.AddFlag("mx", NewArg(WithType(types.Single), WithDefaultValue("d"), WithMutex("g")), s.flagPath...); !errors.Is(err, errs.ErrDefaultInExclusiveGroup) {
+					t.Errorf("mutex+default should be rejected at construction; got %v", err)
+				}
+				p = mk(t)
+				if err := p.AddFlag("xo", NewArg(WithType(types.Single), WithDefaultValue("d"), WithExactlyOne("g")), s.flagPath...); !errors.Is(err, errs.ErrDefaultInExclusiveGroup) {
+					t.Errorf("exactlyone+default should be rejected at construction; got %v", err)
+				}
+			})
+
 			// (B) bad default, no value -> validators are NOT run on the default.
 			t.Run("bad_default_bypasses_validators", func(t *testing.T) {
 				p := mk(t)
@@ -612,6 +624,45 @@ func TestInteractionMatrixBindDefault(t *testing.T) {
 		p.Parse([]string{os.Args[0], "--f", "x"})
 		if v != "x" {
 			t.Errorf("override: bound=%q, want %q", v, "x")
+		}
+	})
+}
+
+// promptDetector is a TerminalReader that records whether the interactive prompt
+// was ever invoked — so a test can prove an env var was used *in lieu of* prompting.
+type promptDetector struct{ prompted *bool }
+
+func (d promptDetector) ReadPassword(fd int) ([]byte, error) {
+	*d.prompted = true
+	return nil, errors.New("unexpected interactive prompt")
+}
+func (d promptDetector) IsTerminal(fd int) bool { return true }
+
+// TestInteractionMatrixSecureEnv verifies a required `secure` flag is satisfied by
+// an environment variable in lieu of the interactive prompt (CI/CD-friendly): the
+// required check passes, the value is taken from the environment, and the terminal
+// is never read.
+func TestInteractionMatrixSecureEnv(t *testing.T) {
+	conv := func(s string) string { return strings.ToUpper(strings.ReplaceAll(s, "-", "_")) }
+	t.Run("env satisfies required secure flag without prompting", func(t *testing.T) {
+		t.Setenv("TOKEN", "s3cret")
+		prompted := false
+		var token string
+		p := NewParser()
+		p.SetEnvNameConverter(conv)
+		p.SetTerminalReader(promptDetector{&prompted})
+		if err := p.BindFlag(&token, "token", NewArg(WithType(types.Single), WithSecurePrompt("Token: "), WithRequired(true))); err != nil {
+			t.Fatal(err)
+		}
+		p.Parse([]string{os.Args[0]})
+		if hasErr(p, errs.ErrRequiredFlag) {
+			t.Errorf("env should satisfy the required secure flag; got %v", p.GetErrors())
+		}
+		if prompted {
+			t.Errorf("secure flag prompted despite the env var being set — env should replace the prompt")
+		}
+		if token != "s3cret" {
+			t.Errorf("secure value = %q, want %q (from env)", token, "s3cret")
 		}
 	})
 }

--- a/v2/interaction_matrix_test.go
+++ b/v2/interaction_matrix_test.go
@@ -805,3 +805,63 @@ func TestInteractionMatrixHooks(t *testing.T) {
 		})
 	}
 }
+
+// TestInteractionMatrixMultipleCommands exercises invoking several sibling commands
+// in one line (`cmd1 --flags cmd2 --flags`): each command runs, its flags resolve to
+// it without bleed, and per-command contracts stay scoped to their command even when
+// both are active. The cross-fire case is a regression guard — same-labelled groups
+// in two simultaneously-invoked commands must NOT merge.
+func TestInteractionMatrixMultipleCommands(t *testing.T) {
+	var trace []string
+	build := func(t *testing.T) *Parser {
+		t.Helper()
+		trace = nil
+		p := NewParser()
+		mk := func(name string) *Command {
+			return NewCommand(WithName(name), WithCallback(func(p *Parser, c *Command) error {
+				trace = append(trace, name)
+				return nil
+			}))
+		}
+		if err := p.AddCommand(mk("cmd1")); err != nil {
+			t.Fatal(err)
+		}
+		if err := p.AddCommand(mk("cmd2")); err != nil {
+			t.Fatal(err)
+		}
+		// Both commands carry a mutex group reusing the SAME label "g".
+		mustAddFlag(t, p, "a", newStandalone(WithMutex("g")), "cmd1")
+		mustAddFlag(t, p, "b", newStandalone(WithMutex("g")), "cmd1")
+		mustAddFlag(t, p, "c", newStandalone(WithMutex("g")), "cmd2")
+		mustAddFlag(t, p, "d", newStandalone(WithMutex("g")), "cmd2")
+		return p
+	}
+
+	t.Run("both commands run in order; flags resolve per command", func(t *testing.T) {
+		p := build(t)
+		p.Parse([]string{os.Args[0], "cmd1", "--a", "cmd2", "--c"})
+		p.ExecuteCommands()
+		if strings.Join(trace, " ") != "cmd1 cmd2" {
+			t.Errorf("both commands should run in order; trace=%v", trace)
+		}
+		if !p.HasFlag("a", "cmd1") || !p.HasFlag("c", "cmd2") || p.HasFlag("a", "cmd2") {
+			t.Errorf("flags should resolve per command without bleed")
+		}
+	})
+
+	t.Run("same-label contracts stay scoped per command (no cross-fire)", func(t *testing.T) {
+		p := build(t)
+		p.Parse([]string{os.Args[0], "cmd1", "--a", "cmd2", "--c"}) // a@cmd1 and c@cmd2 — different commands
+		if hasErr(p, errs.ErrMutexViolation) {
+			t.Errorf("a@cmd1 and c@cmd2 must not cross-fire the shared label; got %v", p.GetErrors())
+		}
+	})
+
+	t.Run("real same-command violation still fires", func(t *testing.T) {
+		p := build(t)
+		p.Parse([]string{os.Args[0], "cmd1", "--a", "--b", "cmd2"}) // a,b both in cmd1
+		if !hasErr(p, errs.ErrMutexViolation) {
+			t.Errorf("a,b in cmd1 should fire mutex; got %v", p.GetErrors())
+		}
+	})
+}


### PR DESCRIPTION
fix(contract):verbose repeating of executed command in error output 
fix(flags): make specifying both default and required a config time-error 
improve(docs): document contracts in command scop, better cross-references 
fix(i18n): inconsistencies in quoting and placeholders feat(test): add interaction matrix tests